### PR TITLE
embed-resource function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,45 @@ to this iconset:
 
 
 
+Functions
+=========
+
+embed-resource
+--------------
+
+The ``embed-resource`` function embeds a resource (e.g. svg) as
+base64 encoded url.
+
+Example:
+
+.. code:: scss
+
+    .something {
+        background: embed-resource("images/foo.svg");
+    }
+
+The function is able to fill colors in SVGs.
+This can be done with either XPath or CSS selectors.
+
+Since lxml is used for filling the SVGs and SVGs are namespaced
+XML documents, the expressions must be namespaced as well.
+This leads to problems when converting certain CSS selectors
+since CSS does not support namespaces.
+
+Example:
+
+.. code:: scss
+
+    .foo {
+        background: embed-resource("soccer.svg", $fill-css:['#pentagon': red]);
+    }
+
+    .bar {
+        background: embed-resource("soccer.svg", $fill-xpath:['//*[@id="black_stuff"]/*[local-name()="g"][1]': red]);
+    }
+
+
+
 SCSS Mixins
 ===========
 

--- a/ftw/theming/browser/theming_variables.py
+++ b/ftw/theming/browser/theming_variables.py
@@ -1,18 +1,11 @@
 from collections import OrderedDict
 from ftw.theming.interfaces import ISCSSCompiler
+from ftw.theming.utils import find_object_in_stack
 from operator import methodcaller
 from Products.Five import BrowserView
 from scss.calculator import Calculator
 from scss.types import Null
 from zope.component import getMultiAdapter
-import inspect
-
-
-def find_object_in_stack(name, klass):
-    frame = inspect.currentframe()
-    while not isinstance(frame.f_locals.get(name, None), klass):
-        frame = frame.f_back
-    return frame.f_locals[name]
 
 
 class ThemingVariablesView(BrowserView):

--- a/ftw/theming/browser/theming_variables.py
+++ b/ftw/theming/browser/theming_variables.py
@@ -25,8 +25,10 @@ class ThemingVariablesView(BrowserView):
         def register_theming_variables(*varnames):
             calculator = find_object_in_stack('self', Calculator)
             variables = calculator.namespace.variables
-            package = variables.get('$current-package').render().strip('"').strip("'")
-            filename = variables.get('$current-filename').render().strip('"').strip("'")
+            package = (variables.get('$current-package').render()
+                       .strip('"').strip("'"))
+            filename = (variables.get('$current-filename').render()
+                        .strip('"').strip("'"))
             varnames = map(methodcaller('render'), varnames)
 
             if package not in packages:

--- a/ftw/theming/compiler.py
+++ b/ftw/theming/compiler.py
@@ -32,9 +32,11 @@ class SCSSCompiler(object):
     def _get_scss_files(self):
         def make_source_file(resource):
             package = resource.name.split(':')[0]
-            filename = resource.name.split(':')[-1].split('/')[-1]
+            relpath = resource.name.split(':')[-1]
+            filename = relpath.split('/')[-1]
             source = u'\n'.join((
                     u'$current-package: "{0}";'.format(package),
+                    u'$current-relpath: "{0}";'.format(relpath),
                     u'$current-filename: "{0}";'.format(filename),
                     resource.get_source(self.context, self.request)))
             if ISCSSFileResource.providedBy(resource):

--- a/ftw/theming/compiler.py
+++ b/ftw/theming/compiler.py
@@ -40,7 +40,8 @@ class SCSSCompiler(object):
                     u'$current-filename: "{0}";'.format(filename),
                     resource.get_source(self.context, self.request)))
             if ISCSSFileResource.providedBy(resource):
-                source_file = SourceFile.from_string(source, Path(str(resource.path)))
+                source_file = SourceFile.from_string(
+                    source, Path(str(resource.path)))
                 source_file.origin = Path(str(resource.path))
                 return source_file
             else:

--- a/ftw/theming/extensions.py
+++ b/ftw/theming/extensions.py
@@ -1,7 +1,15 @@
+from ftw.theming.browser.theming_variables import find_object_in_stack
+from lxml import etree
+from lxml.cssselect import CSSSelector
+from path import Path
+from scss.calculator import Calculator
 from scss.extension import Extension
 from scss.namespace import Namespace
 from scss.types import Boolean
+from scss.types import Url
+from zope.dottedname.resolve import resolve
 import inspect
+import mimetypes
 
 
 class ThemingExtensions(Extension):
@@ -18,3 +26,48 @@ def function_exists(name):
     functions = calculator.namespace._functions
     function_names = dict(functions.keys()).keys()
     return Boolean(name.render() in function_names)
+
+
+@ThemingExtensions.namespace.declare
+def embed_resource(relpath, fill_css=None, fill_xpath=None):
+    path = find_relative_resource(relpath)
+    mimetype, _compression = mimetypes.guess_type(path)
+    data = path.bytes()
+    data = fill_svg(data, fill_css=fill_css, fill_xpath=fill_xpath)
+    return Url(u'data:{0};base64,{1}'.format(
+        mimetype.decode('utf-8'),
+        data.encode('base64').decode('utf-8')))
+
+
+def find_relative_resource(relpath):
+    calculator = find_object_in_stack('self', Calculator)
+    variables = calculator.namespace.variables
+    package = variables.get('$current-package').render().strip('"').strip("'")
+    module = resolve(package)
+    filename = variables.get('$current-relpath').render().strip('"').strip("'")
+    directory = Path(module.__file__).parent.joinpath(filename).parent
+    path = directory.joinpath(relpath.render().strip('"').strip("'")).abspath()
+    if not path.isfile():
+        raise ValueError('{0}: File does not exist: {1}'.format(
+            filename, path))
+    return path
+
+
+def fill_svg(data, fill_css=None, fill_xpath=None):
+    doc = etree.fromstring(data)
+    expressions = []
+
+    for xpr, color in fill_xpath or ():
+        xpath_xpr = xpr.render().strip('"').strip("'")
+        expressions.append((xpath_xpr, color))
+
+    for xpr, color in fill_css or ():
+        css_xpr = xpr.render().strip('"').strip("'")
+        xpath_xpr = CSSSelector(css_xpr).path
+        expressions.append((xpath_xpr, color))
+
+    for xpath_xpr, color in expressions:
+        for node in doc.xpath(xpath_xpr):
+            node.attrib['fill'] = color.render()
+
+    return etree.tostring(doc)

--- a/ftw/theming/extensions.py
+++ b/ftw/theming/extensions.py
@@ -1,4 +1,4 @@
-from ftw.theming.browser.theming_variables import find_object_in_stack
+from ftw.theming.utils import find_object_in_stack
 from lxml import etree
 from lxml.cssselect import CSSSelector
 from path import Path

--- a/ftw/theming/utils.py
+++ b/ftw/theming/utils.py
@@ -1,0 +1,8 @@
+import inspect
+
+
+def find_object_in_stack(name, klass):
+    frame = inspect.currentframe()
+    while not isinstance(frame.f_locals.get(name, None), klass):
+        frame = frame.f_back
+    return frame.f_locals[name]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ setup(name='ftw.theming',
 
       install_requires=[
         'Plone',
+        'cssselect',
         'ftw.upgrade',
+        'lxml',
         'path.py',
         'pyScss >= 1.3',
         'setuptools',


### PR DESCRIPTION
Add embed-resource function for embedding svgs.

The embed-resource function is able to fill svgs based on
css and xpath selectors.

Be aware that SVGs are namespaced (!) XMLs, therefore it is quite
hard to find the right selector and not all CSS selectors may be
convertable to XPath.
