### PR TITLE
Implement client-side caching.

### DIFF
--- a/ftw/theming/tests/test_theming_css_view.py
+++ b/ftw/theming/tests/test_theming_css_view.py
@@ -1,15 +1,21 @@
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from ftw.theming.interfaces import ISCSSCompiler
 from ftw.theming.tests import FunctionalTestCase
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.component import adapts
+from zope.event import notify
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Interface
+from zope.lifecycleevent import ObjectModifiedEvent
+import re
 import transaction
 
 
@@ -35,7 +41,7 @@ class TestThemingCSSView(FunctionalTestCase):
     @browsing
     def test_css_included_in_html(self, browser):
         browser.open()
-        self.assertIn('http://nohost/plone/theming.css', self.get_css_urls(browser))
+        self.assert_css_url_present('http://nohost/plone/theming.css')
 
     @browsing
     def test_css_included_relative_to_navigation_root(self, browser):
@@ -43,12 +49,12 @@ class TestThemingCSSView(FunctionalTestCase):
         folder = create(Builder('folder').titled('Folder'))
 
         browser.login().open(folder)
-        self.assertIn('http://nohost/plone/theming.css', self.get_css_urls(browser))
+        self.assert_css_url_present('http://nohost/plone/theming.css')
 
         alsoProvides(folder, INavigationRoot)
         transaction.commit()
         browser.reload()
-        self.assertIn('http://nohost/plone/folder/theming.css', self.get_css_urls(browser))
+        self.assert_css_url_present('http://nohost/plone/folder/theming.css')
 
     def test_css_is_cached(self):
         self.register_compiler_mock()
@@ -71,25 +77,57 @@ class TestThemingCSSView(FunctionalTestCase):
         self.assertEquals(2, self.view(), 'Caching should be disabled in debug mode.')
         self.assertEquals(3, self.view(), 'Caching should be disabled in debug mode.')
 
-    def test_no_cache_header_disables_caching(self):
-        self.register_compiler_mock()
-        self.assertEquals(1, self.view())
-        self.assertEquals(1, self.view(), 'Cache does not work...')
-        self.request.environ['CACHE_CONTROL'] = 'no-cache'
-        self.assertEquals(2, self.view(), 'no-cache header does not work')
-        self.assertEquals(3, self.view(), 'no-cache header does not work')
-        self.request.environ['CACHE_CONTROL'] = 'no-transform'
-        self.assertEquals(3, self.view(),
-                          'no-cache header should flush the cache for later requests.')
-        self.assertEquals(3, self.view(),
-                          'no-cache header should flush the cache for later requests.')
-
     def test_recooking_portal_css_flushes_cache(self):
         self.register_compiler_mock()
         self.assertEquals(1, self.view())
         self.assertEquals(1, self.view(), 'Cache does not work...')
         self.portal_css.cookResources()
         self.assertEquals(2, self.view(), 'Recooking portal_css should flush cache.')
+
+    @browsing
+    def test_caching_active_when_debugmode_disabled(self, browser):
+        self.portal_css.setDebugMode(False)
+        browser.open()
+        theming_css_url = self.get_css_url('http://nohost/plone/theming.css')
+        self.assertIn('?cachekey=', theming_css_url, 'Missing cachekey param.')
+
+        browser.open(theming_css_url)
+        self.assertEquals('private, max-age=31536000',
+                          browser.headers['Cache-Control'],
+                          'Cache headers should be set.')
+
+    @browsing
+    def test_caching_inactive_when_debugmode_enabled(self, browser):
+        self.portal_css.setDebugMode(True)
+        browser.open()
+        theming_css_url = self.get_css_url('http://nohost/plone/theming.css')
+        self.assertEquals('http://nohost/plone/theming.css', theming_css_url,
+                          'Cachekey param should not be set in debug mode.')
+
+        browser.open(theming_css_url)
+        self.assertNotIn('Cache-Control', browser.headers,
+                         'Cache-Control headers should not be set in debug mode.')
+
+    @browsing
+    def test_cachekey_refreshes_when_navroot_changes(self, browser):
+        with freeze(datetime(2015, 1, 2, 3, 4)) as clock:
+            self.portal_css.setDebugMode(False)
+            self.grant('Manager')
+            navroot = create(Builder('folder')
+                             .titled('Folder')
+                             .providing(INavigationRoot))
+
+            browser.open(navroot)
+            css_base_url = 'http://nohost/plone/folder/theming.css'
+            self.assert_css_url_present(css_base_url)
+            theming_css_url = self.get_css_url(css_base_url)
+
+            clock.forward(hours=1)
+            navroot.reindexObject()  # updates modified date
+            transaction.commit()
+            browser.reload()
+            self.assertNotEqual(theming_css_url, self.get_css_url(css_base_url),
+                                'Cachekey should be refreshed when navroot changes.')
 
     def register_compiler_mock(self):
         sitemanager = self.portal.getSiteManager()
@@ -107,5 +145,19 @@ class TestThemingCSSView(FunctionalTestCase):
                 COMPILER_MOCK_DATA['counter'] += 1
                 return COMPILER_MOCK_DATA['counter']
 
-    def get_css_urls(self, browser):
+    def list_css_urls(self):
         return [node.attrib.get('href') for node in browser.css('link')]
+
+    def get_css_url(self, urlbase):
+        xpr = re.compile(r'^{0}($|\?)'.format(re.escape(urlbase)))
+        urls = filter(xpr.match, self.list_css_urls())
+        try:
+            url, = urls
+        except ValueError:
+            return None
+        else:
+            return url
+
+    def assert_css_url_present(self, url):
+        assert self.get_css_url(url), \
+            'No CSS URL "{0}" found in {1}'.format(url, self.list_css_urls())

--- a/ftw/theming/viewlets/theming_css.py
+++ b/ftw/theming/viewlets/theming_css.py
@@ -1,4 +1,5 @@
 from plone.app.layout.navigation.root import getNavigationRootObject
+from ftw.theming.browser.theming_css import get_css_cache_key
 from plone.app.layout.viewlets.common import ViewletBase
 from Products.CMFCore.utils import getToolByName
 
@@ -11,8 +12,12 @@ class ThemingCSS(ViewletBase):
         return self.template.format(href=self.css_url())
 
     def css_url(self):
-        return '{0}/theming.css'.format(
-            self.get_navigation_root().absolute_url())
+        navroot_url = self.get_navigation_root().absolute_url()
+        css_url = '{0}/theming.css'.format(navroot_url)
+        cachekey = get_css_cache_key(self.context)
+        if cachekey:
+            css_url += '?cachekey={0}'.format(cachekey)
+        return css_url
 
     def get_navigation_root(self):
         portal = getToolByName(self.context, 'portal_url').getPortalObject()


### PR DESCRIPTION
The theming.css is now cached in the browser cached because we set cache
control headers.

In order to be able to invalidate the cache we add a cachekey param to
the css url, so that we just can change the param and thus the URL in
order to invalidate the cache.

The cachekey is generated per navigation root and contains the URL to
the navigation root, a portal_css bundle compilation state hash and the
modified date of the navigation root.
The cachekey changes when the portal_css bundles are recooked or when
the navigation root is changed.

When the portal_css debug mode is enabled, caching is disabled
altogether by not appending a cachekey param.

Removed cache-invalidation on shift-reload because any user can
invalidate the server-side cache and force a sass compilation, which is
in fact a DDoS vector.

/ @maethu @bierik 