### PR TITLE
add theming.css redirect on non-navroots

### DIFF
--- a/ftw/theming/browser/configure.zcml
+++ b/ftw/theming/browser/configure.zcml
@@ -6,6 +6,13 @@
 
     <browser:page
         name="theming.css"
+        for="*"
+        class=".theming_css.RedirectToNavrootThemingCSSView"
+        permission="zope.Public"
+        />
+
+    <browser:page
+        name="theming.css"
         for="plone.app.layout.navigation.interfaces.INavigationRoot"
         class=".theming_css.ThemingCSSView"
         permission="zope.Public"

--- a/ftw/theming/viewlets/theming_css.py
+++ b/ftw/theming/viewlets/theming_css.py
@@ -1,7 +1,5 @@
-from plone.app.layout.navigation.root import getNavigationRootObject
-from ftw.theming.browser.theming_css import get_css_cache_key
+from ftw.theming.browser.theming_css import get_theming_css_url
 from plone.app.layout.viewlets.common import ViewletBase
-from Products.CMFCore.utils import getToolByName
 
 
 class ThemingCSS(ViewletBase):
@@ -9,16 +7,4 @@ class ThemingCSS(ViewletBase):
     template = '<link rel="stylesheet" type="text/css" href="{href}" />'
 
     def render(self):
-        return self.template.format(href=self.css_url())
-
-    def css_url(self):
-        navroot_url = self.get_navigation_root().absolute_url()
-        css_url = '{0}/theming.css'.format(navroot_url)
-        cachekey = get_css_cache_key(self.context)
-        if cachekey:
-            css_url += '?cachekey={0}'.format(cachekey)
-        return css_url
-
-    def get_navigation_root(self):
-        portal = getToolByName(self.context, 'portal_url').getPortalObject()
-        return getNavigationRootObject(self.context, portal)
+        return self.template.format(href=get_theming_css_url(self.context))


### PR DESCRIPTION
The theming.css may be requested on any context.
In order to make the client-side cache work efficiently we only want to
have theming.css-requests on navigation roots.

Therefore all requests on non-navigation-roots are redirected to the
next parent navigation root, adding the cachekey param.

This fixes a TinyMCE problem:
When "theming.css" is configured as TinyMCE content CSS resource, it is
requested relative to the current context, which breaks caching because
the URL always changes.

@maethu please take a look