### PR TITLE
Define fallbackfont variable.

### DIFF
--- a/ftw/theming/resources/scss/default_variables.scss
+++ b/ftw/theming/resources/scss/default_variables.scss
@@ -61,6 +61,7 @@ $border-radius: 3px !default;
 
 $font-family-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $font-family-serif: Georgia, "Times New Roman", Times, serif !default;
+$font-family-fallback: "Times New Roman", Times, serif;
 $font-family-monospace: Menlo, Monaco, Consolas, "Courier New", monospace !default;
 $font-family-base: $font-family-sans-serif !default;
 $font-size-base: 14px !default;


### PR DESCRIPTION
The fallbackfont in the normalize css is set to ```serif```. If the host system has no font for this definition some chars which are not defined in the base font family are not displayed correctly. So the most save font for the web is ```Times```.