### PR TITLE
Caching in development mode

### DIFF
--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -31,8 +31,8 @@ def debug_mode_enabled():
     return bool(cssregistry.getDebugMode())
 
 
-def get_css_cache_key(context):
-    if debug_mode_enabled():
+def get_css_cache_key(context, debug_mode_caching=True):
+    if not debug_mode_caching and debug_mode_enabled():
         return None
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
@@ -40,11 +40,21 @@ def get_css_cache_key(context):
     key = [navroot.absolute_url(),
            compute_css_bundle_hash(navroot),
            str(navroot.modified().millis())]
+
+    if debug_mode_enabled():
+        key.append(get_compiler_cachekey(context))
+
     return '.'.join(key).encode('base64').strip()
 
 
+def get_compiler_cachekey(context):
+    request = context.REQUEST
+    compiler = getMultiAdapter((context, request), ISCSSCompiler)
+    return compiler.get_cachekey()
+
+
 def ramcachekey(func, self):
-    cachekey = get_css_cache_key(self.context)
+    cachekey = get_css_cache_key(self.context, debug_mode_caching=False)
     if cachekey is None:
         raise ram.DontCache
     return cachekey

--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -8,6 +8,7 @@ from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import getSite
+import hashlib
 
 
 def compute_css_bundle_hash(context):
@@ -44,7 +45,7 @@ def get_css_cache_key(context, debug_mode_caching=True):
     if debug_mode_enabled():
         key.append(get_compiler_cachekey(context))
 
-    return '.'.join(key).encode('base64').strip()
+    return hashlib.md5('.'.join(key)).hexdigest()
 
 
 def get_compiler_cachekey(context):

--- a/ftw/theming/compiler.py
+++ b/ftw/theming/compiler.py
@@ -10,6 +10,7 @@ from zope.component import adapts
 from zope.component import getUtility
 from zope.interface import implements
 from zope.interface import Interface
+import hashlib
 import os.path
 
 
@@ -28,6 +29,14 @@ class SCSSCompiler(object):
     def compile_scss_string(self, source, debug=False):
         source_file = SourceFile.from_string(source)
         return self._compile((source_file,), debug=debug)
+
+    def get_cachekey(self):
+        registry = getUtility(ISCSSRegistry)
+        resources = registry.get_resources(self.context, self.request)
+        result = hashlib.md5()
+        map(result.update, (resource.get_cachekey(self.context, self.request)
+                            for resource in resources))
+        return result.hexdigest()
 
     def _get_scss_files(self):
         def make_source_file(resource):

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -116,6 +116,18 @@ class ISCSSResource(Interface):
         :rtype: string
         """
 
+    def get_cachekey(context, request):
+        """Returns a string which changes when the content source
+        changes.
+
+        :param context: A acquisition wrapped context object.
+        :type context: object
+        :param request: The request object.
+        :type request: object
+        :returns: cache string
+        :rtype: string
+        """
+
 
 class ISCSSFileResource(ISCSSResource):
     """A scss resource represents a scss file for registering in the scss registry.

--- a/ftw/theming/profileinfo.py
+++ b/ftw/theming/profileinfo.py
@@ -1,3 +1,4 @@
+from plone.memoize import instance
 from Products.CMFCore.utils import getToolByName
 import re
 
@@ -7,6 +8,7 @@ class ProfileInfo(object):
     def __init__(self, context):
         self.context = context
 
+    @instance.memoize
     def is_profile_installed(self, profileid):
         profileid = re.sub(r'^profile\-', '', profileid)
         quickinstaller = getToolByName(self.context, 'portal_quickinstaller')

--- a/ftw/theming/registry.py
+++ b/ftw/theming/registry.py
@@ -3,6 +3,7 @@ from ftw.theming.exceptions import CyclicResourceOrder
 from ftw.theming.interfaces import ISCSSRegistry
 from ftw.theming.interfaces import ISCSSResourceFactory
 from ftw.theming.interfaces import SLOTS
+from ftw.theming.profileinfo import ProfileInfo
 from tarjan import tarjan
 from zope.interface import implements
 
@@ -24,6 +25,7 @@ class SCSSRegistry(object):
                                map(slot_lookup.get, SLOTS)))
 
         if not include_unavailable:
+            profileinfo = profileinfo or ProfileInfo(context)
             resources = filter(
                 lambda res: res.available(context, request, profileinfo),
                 resources)

--- a/ftw/theming/resource.py
+++ b/ftw/theming/resource.py
@@ -6,6 +6,7 @@ from path import Path
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from zope.interface import implements
 from zope.interface import Interface
+import hashlib
 
 
 class SCSSResource(object):
@@ -30,6 +31,9 @@ class SCSSResource(object):
 
     def get_source(self, context, request):
         return self.source
+
+    def get_cachekey(self, context, request):
+        return hashlib.md5(self.get_source(context, request)).hexdigest()
 
 
 class SCSSFileResource(SCSSResource):
@@ -70,6 +74,9 @@ class SCSSFileResource(SCSSResource):
 
     def get_source(self, context, request):
         return self.path.text('utf-8')
+
+    def get_cachekey(self, context, request):
+        return str(self.path.mtime)
 
     @staticmethod
     def _resolve_path(package, relative_path):

--- a/ftw/theming/tests/test_compiler.py
+++ b/ftw/theming/tests/test_compiler.py
@@ -27,3 +27,9 @@ class TestCompiler(FunctionalTestCase):
         result = compiler.compile_scss_string('$red: red;'
                                               'body { background-color: $red; }')
         self.assertEquals('body{background-color:red}', result.strip())
+
+    def test_get_cachekey_returns_a_value(self):
+        # The cachekey is based on the modified date of the resource,
+        # which changes and therefore we just test that it is positive.
+        compiler = getMultiAdapter((self.portal, self.request), ISCSSCompiler)
+        self.assertTrue(compiler.get_cachekey())

--- a/ftw/theming/tests/test_file_resource.py
+++ b/ftw/theming/tests/test_file_resource.py
@@ -71,3 +71,9 @@ class TestSCSSFileResource(TestCase):
             resource.get_source(CONTEXT, REQUEST))
         self.assertEquals(unicode, type(resource.get_source(CONTEXT, REQUEST)),
                           'Source should be unicode.')
+
+    def test_get_cachekey_returns_a_value(self):
+        # The cachekey is based on the modified date of the resource,
+        # which changes and therefore we just test that it is positive.
+        resource = SCSSFileResource('ftw.theming.tests', 'resources/foo.scss')
+        self.assertTrue(resource.get_cachekey(None, None))

--- a/ftw/theming/tests/test_profileinfo.py
+++ b/ftw/theming/tests/test_profileinfo.py
@@ -18,16 +18,17 @@ class TestProfileInfo(FunctionalTestCase):
         self.quickinstaller = getToolByName(self.portal, 'portal_quickinstaller')
 
     def test_is_profile_installed(self):
-        info = ProfileInfo(self.portal)
-
         with create(self.package_builder).zcml_loaded(self.layer['configurationContext']):
+            info = ProfileInfo(self.portal)
             self.assertFalse(info.is_profile_installed('profile-the.package:default'))
             self.assertFalse(info.is_profile_installed('the.package:default'))
 
+            info = ProfileInfo(self.portal)
             self.portal_setup.runAllImportStepsFromProfile('profile-the.package:default')
             self.assertTrue(info.is_profile_installed('profile-the.package:default'))
             self.assertTrue(info.is_profile_installed('the.package:default'))
 
+            info = ProfileInfo(self.portal)
             self.quickinstaller.uninstallProducts(['the.package'])
             self.assertFalse(info.is_profile_installed('profile-the.package:default'))
             self.assertFalse(info.is_profile_installed('the.package:default'))

--- a/ftw/theming/tests/test_resource.py
+++ b/ftw/theming/tests/test_resource.py
@@ -29,3 +29,16 @@ class TestSCSSResource(TestCase):
         resource = SCSSResource('foo.scss', source=u'$foreground = black;')
         self.assertEquals(u'$foreground = black;',
                           resource.get_source(CONTEXT, REQUEST))
+
+    def test_cachekey_is_compiled_from_source(self):
+        resource = SCSSResource('foo.scss', source=u'$foreground = black;')
+        self.assertEquals('37a986b6ad84bf77261bf3796a01b458',
+                          resource.get_cachekey(None, None))
+
+        resource = SCSSResource('foo.scss', source=u'$foreground = black;')
+        self.assertEquals('37a986b6ad84bf77261bf3796a01b458',
+                          resource.get_cachekey(None, None))
+
+        resource = SCSSResource('foo.scss', source=u'$foreground = red;')
+        self.assertEquals('e7d3c829ae8433699c7c061fd87b5fd6',
+                          resource.get_cachekey(None, None))


### PR DESCRIPTION
In order to make development faster we cache the compiled CSS even when the debug mode is active.
When the debug mode is active we include a cachekey for each resource which changes when any file or result of a dynamic resource has changed.

The developer does not need to care about the cache. When in doupt, a shift-reload does always recompile.

Also use md5 instead of base64 for the cachekey in order to avoid newlines.