### PR TITLE
The boxshadow mixin needs to take a variable arguments.

### DIFF
--- a/ftw/theming/resources/scss/standard_mixins.scss
+++ b/ftw/theming/resources/scss/standard_mixins.scss
@@ -47,7 +47,7 @@
 }
 
 
-@mixin boxshadow($definition) {
+@mixin boxshadow($definition...) {
   box-shadow: $definition;
   -webkit-box-shadow: $definition;
   -moz-box-shadow: $definition;


### PR DESCRIPTION
Statements like...

```scss
    @include boxshadow(0 1px 1px transparentize($input-focus-color, .8) inset,
                       0 0 5px transparentize($input-focus-color, .6));
  }

```

.. are valid now. 

See http://stackoverflow.com/questions/7517941/pass-a-list-to-a-mixin-as-a-single-argument-with-sass