### PR TITLE
Fix an error when gzipping the CSS.

### DIFF
--- a/ftw/theming/browser/configure.zcml
+++ b/ftw/theming/browser/configure.zcml
@@ -1,8 +1,12 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.theming">
+
+    <include package="z3c.caching" />
+    <include package="z3c.caching" file="meta.zcml" />
 
     <browser:page
         name="theming.css"
@@ -16,6 +20,11 @@
         for="plone.app.layout.navigation.interfaces.INavigationRoot"
         class=".theming_css.ThemingCSSView"
         permission="zope.Public"
+        />
+
+    <cache:ruleset
+        for="ftw.theming.interfaces.ICSSCaching"
+        ruleset="plone.stableResource"
         />
 
     <browser:page

--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -1,3 +1,4 @@
+from ftw.theming.interfaces import ICSSCaching
 from ftw.theming.interfaces import ISCSSCompiler
 from operator import methodcaller
 from plone.app.layout.navigation.root import getNavigationRootObject
@@ -8,6 +9,7 @@ from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.interface import alsoProvides
 import hashlib
 
 
@@ -81,12 +83,14 @@ class ThemingCSSView(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'text/css; charset=utf-8')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
         if self.request.get('cachekey'):
             # Do not set cache headers when no cachekey provided.
             # The cached representation is to be considered fresh for 1 year
             # http://stackoverflow.com/a/3001556/880628
+            # The cache header is only active when plone.app.caching is not
+            # configured.
             response.setHeader('Cache-Control', 'private, max-age=31536000')
+            alsoProvides(self, ICSSCaching)
         return self.get_css()
 
     @ram.cache(ramcachekey)

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -178,3 +178,8 @@ class ISCSSResourceFactory(Interface):
     def __call__(context, request):
         """Accepts any context and request and returns an SCSSResource object.
         """
+
+
+class ICSSCaching(Interface):
+    """Marker interface for enabling plone.app.caching on the theming resource.
+    """


### PR DESCRIPTION
Depending on the generated CSS, Zope's GZIP compression will fail and result in an invalid response.
In order to mitigate this issue we no longer use ``enableHTTPCompression``.

By configuring a plone.app.caching ruleset we can let plone.app.caching handle the compression, when it is installed and configured.
It will also override the Cache-Control header.
In order to have a Cache-Control header when p.a.caching is not installed or not configured, we still set it.