### PR TITLE
Change caching to include dynamic resource cache keys in production

### DIFF
--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -41,20 +41,13 @@ def get_css_cache_key(context, debug_mode_caching=True):
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
     navroot = getNavigationRootObject(context, portal)
+    compiler = getMultiAdapter((context, context.REQUEST), ISCSSCompiler)
     key = [navroot.absolute_url(),
            compute_css_bundle_hash(navroot),
-           str(navroot.modified().millis())]
-
-    if debug_mode_enabled:
-        key.append(get_compiler_cachekey(context))
+           str(navroot.modified().millis()),
+           compiler.get_cachekey(dynamic_resources_only=not debug_mode_enabled)]
 
     return hashlib.md5('.'.join(key)).hexdigest()
-
-
-def get_compiler_cachekey(context):
-    request = context.REQUEST
-    compiler = getMultiAdapter((context, request), ISCSSCompiler)
-    return compiler.get_cachekey()
 
 
 def ramcachekey(func, self):

--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -29,13 +29,14 @@ def compute_css_bundle_hash(context):
     return str(hash(frozenset(keys)))
 
 
-def debug_mode_enabled():
+def is_debug_mode_enabled():
     cssregistry = getToolByName(getSite(), 'portal_css')
     return bool(cssregistry.getDebugMode())
 
 
 def get_css_cache_key(context, debug_mode_caching=True):
-    if not debug_mode_caching and debug_mode_enabled():
+    debug_mode_enabled = is_debug_mode_enabled()
+    if not debug_mode_caching and debug_mode_enabled:
         return None
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
@@ -44,7 +45,7 @@ def get_css_cache_key(context, debug_mode_caching=True):
            compute_css_bundle_hash(navroot),
            str(navroot.modified().millis())]
 
-    if debug_mode_enabled():
+    if debug_mode_enabled:
         key.append(get_compiler_cachekey(context))
 
     return hashlib.md5('.'.join(key)).hexdigest()
@@ -96,7 +97,7 @@ class ThemingCSSView(BrowserView):
     @ram.cache(ramcachekey)
     def get_css(self):
         compiler = getMultiAdapter((self.context, self.request), ISCSSCompiler)
-        return compiler.compile(debug=debug_mode_enabled())
+        return compiler.compile(debug=is_debug_mode_enabled())
 
     def invalidate_cache(self):
         cache = getUtility(ICacheChooser)('{0}.get_css'.format(__name__))

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -147,6 +147,35 @@ class ISCSSResource(Interface):
         """
 
 
+class IDynamicSCSSResource(ISCSSResource):
+    """A dynamic SCSS resource provides SCSS source which may change.
+    In order to have the correct caching, a cachekey is necessary.
+
+    Dynamic resources should either subclass the DynamicSCSSResource class or
+    initialize it with at least a name, a source and a cache key.
+    """
+
+    def __init__(name, slot='addon', before=None, after=None, source=u''):
+        """Initialize an scss resource.
+
+        :param name: The name of the resource.
+        :type name: string
+        :param slot: The slot where the resource belongs. This must be one of
+          the list of slots.
+        :type slot: string
+        :param before: Move this resource before the other resource with that
+          name within the same slot.
+        :type before: string (name of other resource)
+        :param after: Move this resource after the other resource with that
+          name within the same slot.
+        :type after: string (name of other resource)
+        :param source: The SCSS source.
+        :type source: string
+        :param cachekey: The cache key which must change when the source changes.
+        :type source: string
+        """
+
+
 class ISCSSFileResource(ISCSSResource):
     """A scss resource represents a scss file for registering in the scss registry.
     It holds the relevant information for building the scss pipeline.

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -84,6 +84,24 @@ class ISCSSResource(Interface):
     after = Attribute('Move this resource after the other resource with that'
                       ' name within the same slot.')
 
+    def __init__(name, slot='addon', before=None, after=None, source=u''):
+        """Initialize an scss resource.
+
+        :param name: The name of the resource.
+        :type name: string
+        :param slot: The slot where the resource belongs. This must be one of
+          the list of slots.
+        :type slot: string
+        :param before: Move this resource before the other resource with that
+          name within the same slot.
+        :type before: string (name of other resource)
+        :param after: Move this resource after the other resource with that
+          name within the same slot.
+        :type after: string (name of other resource)
+        :param source: The SCSS source.
+        :type source: string
+        """
+
     def available(context, request, profileinfo=None):
         """Check whether the resource is available for this context.
 
@@ -141,7 +159,7 @@ class ISCSSFileResource(ISCSSResource):
     def __init__(package, relative_path, slot='addon',
                  profile=None, for_=INavigationRoot, layer=Interface,
                  before=None, after=None):
-        """Initialize a scss resource.
+        """Initialize an scss resource.
 
         :param package: The name of the python package where the resource is
           registered.

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -70,6 +70,18 @@ class ISCSSRegistry(Interface):
         :rtype: list of :py:class:`ftw.theming.interfaces.ISCSSFileResource`
         """
 
+    def get_raw_dynamic_resources(context, request):
+        """Returns all dynamic resources without ordering or filtering them.
+        This is an efficient lookup for doing such as fast cache calculation.
+
+        :param context: A acquisition wrapped context object.
+        :type context: object
+        :param request: The request object.
+        :param request: object
+        :returns: A list of scss resource objects.
+        :rtype: list of :py:class:`ftw.theming.interfaces.IDynamicSCSSResource`
+        """
+
 
 class ISCSSResource(Interface):
     """An SCSS resource has a snippet of SCSS code and can tell whether the

--- a/ftw/theming/registry.py
+++ b/ftw/theming/registry.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from ftw.theming.exceptions import CyclicResourceOrder
+from ftw.theming.interfaces import IDynamicSCSSResource
 from ftw.theming.interfaces import ISCSSRegistry
 from ftw.theming.interfaces import ISCSSResourceFactory
 from ftw.theming.interfaces import SLOTS
@@ -30,6 +31,11 @@ class SCSSRegistry(object):
                 lambda res: res.available(context, request, profileinfo),
                 resources)
         return resources
+
+    def get_raw_dynamic_resources(self, context, request):
+        slot_lookup = self._slot_resources_lookup(context, request)
+        resources = reduce(list.__add__, slot_lookup.values())
+        return filter(IDynamicSCSSResource.providedBy, resources)
 
     def order_resources(self, resources):
         if not resources:

--- a/ftw/theming/resource.py
+++ b/ftw/theming/resource.py
@@ -34,7 +34,8 @@ class SCSSResource(object):
         return self.source
 
     def get_cachekey(self, context, request):
-        return hashlib.md5(self.get_source(context, request)).hexdigest()
+        raise NotImplementedError(
+            'SCSSResource {} has no cachekey'.format(self.name))
 
 
 class DynamicSCSSResource(SCSSResource):

--- a/ftw/theming/resource.py
+++ b/ftw/theming/resource.py
@@ -1,3 +1,4 @@
+from ftw.theming.interfaces import IDynamicSCSSResource
 from ftw.theming.interfaces import ISCSSFileResource
 from ftw.theming.interfaces import ISCSSResource
 from ftw.theming.interfaces import SLOTS
@@ -34,6 +35,30 @@ class SCSSResource(object):
 
     def get_cachekey(self, context, request):
         return hashlib.md5(self.get_source(context, request)).hexdigest()
+
+
+class DynamicSCSSResource(SCSSResource):
+    """A dynamic SCSS resource provides SCSS source which may change.
+    In order to have the correct caching, a cachekey is necessary.
+
+    Dynamic resources should either subclass the DynamicSCSSResource class or
+    initialize it with at least a name, a source and a cache key.
+    """
+    implements(IDynamicSCSSResource)
+
+    def __init__(self, name, slot='addon', before=None, after=None,
+                 source=u'', cachekey=None):
+        super(DynamicSCSSResource, self).__init__(name=name,
+                                                  slot=slot,
+                                                  before=before,
+                                                  after=after,
+                                                  source=source)
+        self.cachekey = cachekey
+
+    def get_cachekey(self, context, request):
+        if not self.cachekey:
+            raise NotImplementedError('No cachekey set.')
+        return self.cachekey
 
 
 class SCSSFileResource(SCSSResource):

--- a/ftw/theming/tests/__init__.py
+++ b/ftw/theming/tests/__init__.py
@@ -1,7 +1,9 @@
+from ftw.theming.interfaces import ISCSSRegistry
 from ftw.theming.testing import THEMING_FUNCTIONAL
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
+from zope.component import getUtility
 import transaction
 
 
@@ -11,6 +13,11 @@ class FunctionalTestCase(TestCase):
     def setUp(self):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
+        self.registry = getUtility(ISCSSRegistry)
+        self.original_resources = self.registry.resources
+
+    def tearDown(self):
+        self.original_resources = self.registry.resources
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, roles)

--- a/ftw/theming/tests/test_registry.py
+++ b/ftw/theming/tests/test_registry.py
@@ -2,6 +2,7 @@ from ftw.theming.exceptions import CyclicResourceOrder
 from ftw.theming.interfaces import ISCSSRegistry
 from ftw.theming.interfaces import ISCSSResourceFactory
 from ftw.theming.registry import SCSSRegistry
+from ftw.theming.resource import DynamicSCSSResource
 from ftw.theming.resource import SCSSFileResource
 from ftw.theming.resource import SCSSResource
 from ftw.theming.tests.stubs import CONTEXT
@@ -166,3 +167,18 @@ class TestSCSSRegistry(TestCase):
         self.assertEquals([], registry.get_resources(CONTEXT, REQUEST))
         self.assertEquals([], registry.get_resources(CONTEXT, REQUEST,
                                                      include_unavailable=True))
+
+    def test_get_raw_dynamic_resources(self):
+        """The get_raw_dynamic_resources method returns all dynamic resources without
+        ordering or filtering. This is much more efficient and can be used for fast
+        cache calculation.
+        """
+        foo = SCSSFileResource('ftw.theming.tests', 'resources/foo.scss')
+        bar = DynamicSCSSResource('bar')
+
+        registry = SCSSRegistry()
+        registry.add_resource(foo)
+        registry.add_resource(bar)
+
+        self.assertEquals([bar],
+                          registry.get_raw_dynamic_resources(None, None))

--- a/ftw/theming/tests/test_resource.py
+++ b/ftw/theming/tests/test_resource.py
@@ -32,19 +32,6 @@ class TestSCSSResource(TestCase):
         self.assertEquals(u'$foreground = black;',
                           resource.get_source(CONTEXT, REQUEST))
 
-    def test_cachekey_is_compiled_from_source(self):
-        resource = SCSSResource('foo.scss', source=u'$foreground = black;')
-        self.assertEquals('37a986b6ad84bf77261bf3796a01b458',
-                          resource.get_cachekey(None, None))
-
-        resource = SCSSResource('foo.scss', source=u'$foreground = black;')
-        self.assertEquals('37a986b6ad84bf77261bf3796a01b458',
-                          resource.get_cachekey(None, None))
-
-        resource = SCSSResource('foo.scss', source=u'$foreground = red;')
-        self.assertEquals('e7d3c829ae8433699c7c061fd87b5fd6',
-                          resource.get_cachekey(None, None))
-
 
 class TestDynamicSCSSResource(TestCase):
 

--- a/ftw/theming/tests/test_resource.py
+++ b/ftw/theming/tests/test_resource.py
@@ -1,4 +1,6 @@
+from ftw.theming.interfaces import IDynamicSCSSResource
 from ftw.theming.interfaces import ISCSSResource
+from ftw.theming.resource import DynamicSCSSResource
 from ftw.theming.resource import SCSSResource
 from ftw.theming.tests.stubs import CONTEXT
 from ftw.theming.tests.stubs import REQUEST
@@ -42,3 +44,20 @@ class TestSCSSResource(TestCase):
         resource = SCSSResource('foo.scss', source=u'$foreground = red;')
         self.assertEquals('e7d3c829ae8433699c7c061fd87b5fd6',
                           resource.get_cachekey(None, None))
+
+
+class TestDynamicSCSSResource(TestCase):
+
+    def test_implements_interface(self):
+        resource = DynamicSCSSResource('foo')
+        verifyObject(ISCSSResource, resource)
+        verifyObject(IDynamicSCSSResource, resource)
+
+    def test_get_cachekey_must_be_implemented(self):
+        resource = DynamicSCSSResource('foo')
+        with self.assertRaises(NotImplementedError):
+            resource.get_cachekey(None, None)
+
+    def test_get_cachekey_can_be_passed_on_initialization(self):
+        resource = DynamicSCSSResource('foo', cachekey='bar')
+        self.assertEquals('bar', resource.get_cachekey(None, None))

--- a/ftw/theming/variables.py
+++ b/ftw/theming/variables.py
@@ -1,14 +1,17 @@
 from ftw.theming.interfaces import ISCSSResourceFactory
-from ftw.theming.resource import SCSSResource
+from ftw.theming.resource import DynamicSCSSResource
 from Products.CMFCore.utils import getToolByName
 from zope.interface import provider
+import hashlib
 
 
 @provider(ISCSSResourceFactory)
 def portal_url_variable_resource_factory(context, request):
     portal_url = getToolByName(context, 'portal_url')().decode('utf-8')
-    return SCSSResource(
+    cachekey = hashlib.md5(portal_url).hexdigest()
+    return DynamicSCSSResource(
         'ftw.theming:portal_url', slot='variables',
         source=u'\n'.join((
                 u'$portal-url: "{0}";'.format(portal_url),
-                u'@include declare-variables(portal-url);')))
+                u'@include declare-variables(portal-url);')),
+        cachekey=cachekey)


### PR DESCRIPTION
Until now, the resource cache keys are only included in development. The idea is that the source does not change when there is no update. Recooking (`portal_css`) will update the cache.

But dynamic resources can change at any given time and demand to be respected in production too.
There is now a new `DynamicSCSSResource` base class, of which the cache key is also used in production.

Background:
In production, we dont want to ask all resources for their cache keys. Getting all resources will also apply ordering and conditions, which is quite slow. Therefore we use the full, slow keys and lookups in development and to as few as possible in production. This has the side effect that in production all dynamic resources are always asked for their cachekeys in an unordered manner without applying any filters.
By not implementing any default cachekeys anymore we make sure that the cachekeys are explicitly implemented when using a `DynamicSCSSResource`. Anyone building such a resource must take care that the cachekey generation is fast, because it will be called on every pageview.

Consequences:
All places which are using the `SCSSResource` class directly will have a failure in cachekey generation now. They must be updated. The `SCSSResource` may only be used for statically generated SCSS - the cachekeys will not be used in production; the `DynamicSCSSResource` may be used in most cases.

Should be merged simultaneously with:
- https://github.com/4teamwork/ftw.simplelayout/pull/219
- https://github.com/OneGov/plonetheme.onegovbear/pull/42