### PR TITLE
add get_url() to theming.css view.

### DIFF
--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -96,6 +96,9 @@ class ThemingCSSView(BrowserView):
         cache = getUtility(ICacheChooser)('{0}.get_css'.format(__name__))
         cache.ramcache.invalidateAll()
 
+    def get_url(self):
+        return get_theming_css_url(self.context)
+
 
 class RedirectToNavrootThemingCSSView(BrowserView):
     """The theming.css should only be shipped on navigation roots,
@@ -106,5 +109,7 @@ class RedirectToNavrootThemingCSSView(BrowserView):
     """
 
     def __call__(self):
-        target = get_theming_css_url(self.context)
-        return self.request.response.redirect(target)
+        return self.request.response.redirect(self.get_url())
+
+    def get_url(self):
+        return get_theming_css_url(self.context)

--- a/ftw/theming/tests/test_theming_css_view.py
+++ b/ftw/theming/tests/test_theming_css_view.py
@@ -169,6 +169,22 @@ class TestThemingCSSView(FunctionalTestCase):
             r'^{}'.format(
                 re.escape('http://nohost/plone/folder/theming.css?cachekey=')))
 
+    def test_view_provides_get_url(self):
+        """For internal use in templates, the view should provide the theming
+        css URL.
+        """
+        portal_css_url = self.portal.restrictedTraverse('theming.css').get_url()
+        self.assertRegexpMatches(
+            portal_css_url,
+            r'^{}'.format(
+                re.escape('http://nohost/plone/theming.css?cachekey=')))
+
+        self.grant('Manager')
+        folder = create(Builder('folder'))
+        folder_css_url = folder.restrictedTraverse('theming.css').get_url()
+        self.assertEquals(portal_css_url, folder_css_url,
+                          'The CSS should always be relative to the root.')
+
     def register_compiler_mock(self):
         sitemanager = self.portal.getSiteManager()
         COMPILER_MOCK_DATA = {'counter': 0,


### PR DESCRIPTION
The get_url() method on the theming.css view returns the full URL to the
theming.css relative to the nearest navigation root with caching
parameters.

It can be used in custom templates, e.g.:

```xml
    <link rel="stylesheet" type="text/css" tal:attributes="href string:context/theming.css/get_url" />
```

Closes #14 