### PR TITLE
add six constraint to version having six.unichr.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(name='ftw.theming',
           'lxml',
           'path.py',
           'pyScss >= 1.3',
+          'six >= 1.4.0',  # six.unichr
           'setuptools',
           'tarjan',
       ],


### PR DESCRIPTION
Fixes:

```python
    Traceback:
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/compiler.py", line 374, in manage_children
        self._manage_children_impl(rule, scope)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/compiler.py", line 408, in _manage_children_impl
        self._get_properties(rule, scope, block)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/compiler.py", line 1107, in _get_properties
        value = calculator.calculate(raw_value, divide=True)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/calculator.py", line 116, in calculate
        result = self.evaluate_expression(expression, divide=divide)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/calculator.py", line 134, in evaluate_expression
        ast = self.parse_expression(expr)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/calculator.py", line 167, in parse_expression
        ast = getattr(parser, target)()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 108, in goal
        expr_lst = self.expr_lst()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 197, in expr_lst
        expr_slst = self.expr_slst()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 206, in expr_slst
        or_expr = self.or_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 214, in or_expr
        and_expr = self.and_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 223, in and_expr
        not_expr = self.not_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 234, in not_expr
        comparison = self.comparison()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 242, in comparison
        a_expr = self.a_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 273, in a_expr
        m_expr = self.m_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 288, in m_expr
        u_expr = self.u_expr()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 317, in u_expr
        atom = self.atom()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 377, in atom
        interpolated_string = self.interpolated_string()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 429, in interpolated_string
        interpolated_string_double = self.interpolated_string_double()
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/grammar/expression.py", line 447, in interpolated_string_double
        parts = [unescape(DOUBLE_STRING_GUTS)]
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/cssdefs.py", line 462, in unescape
        return escape_rx.sub(_unescape_one, string)
      File "..../eggs/pyScss-1.3.4-py2.7.egg/scss/cssdefs.py", line 451, in _unescape_one
        return six.unichr(int(match.group(1), 16))
    AttributeError: 'module' object has no attribute 'unichr'
```
We need at least `six` version `1.4.0`, which added `unichr` support.