### PR TITLE
Use font awesome for mimetype icons

### DIFF
--- a/ftw/theming/browser/icons.py
+++ b/ftw/theming/browser/icons.py
@@ -1,7 +1,11 @@
+from operator import attrgetter
 from operator import methodcaller
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation
 from Products.Five import BrowserView
+from zope.component import getUtility
+import re
 
 
 class ThemingIcons(BrowserView):
@@ -11,3 +15,18 @@ class ThemingIcons(BrowserView):
         return map(methodcaller('getId'),
                    filter(IDynamicViewTypeInformation.providedBy,
                           portal_types.objectValues()))
+
+    def get_mime_types(self):
+        mimetypes_registry = getToolByName(self.context, 'mimetypes_registry')
+        icon_paths = sorted(set(map(attrgetter('icon_path'),
+                                    mimetypes_registry.mimetypes())))
+        normalizer = getUtility(IIDNormalizer)
+
+        def itemize(filename):
+            name = normalizer.normalize(re.sub(r'\.png$', r'', filename))
+            return {
+                'filename': filename,
+                'classes': 'mimetype-icon icon-mimetype-img-{}'.format(name),
+                'normalized_name': name}
+
+        return map(itemize, icon_paths)

--- a/ftw/theming/browser/templates/icons.pt
+++ b/ftw/theming/browser/templates/icons.pt
@@ -64,6 +64,51 @@
                 </tal:TYPE>
 
             </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="2">
+                        <span class="types-with-mimetype-icons-hint"
+                              i18n:translate="">
+                            Types which have mimetype icons:
+                            the default type icon is visible when adding a new object of
+                            this type,
+                            existing objects are usually listed with an icon representing
+                            the mimetype of the object.
+                        </span>
+                    </td>
+            </tfoot>
+        </table>
+
+        <h2 i18n:translate="">Mime Types Icons</h2>
+
+        <table class="theming-mime-type-icons listing nosort">
+            <colgroup>
+                <col width="10%" />
+                <col width="10%" />
+                <col width="80%" />
+            </colgroup>
+            <thead>
+                <tr>
+                    <th i18n:translate="">Original</th>
+                    <th i18n:translate="">Icon</th>
+                    <th i18n:translate="">Name</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tal:MIMETYPE tal:repeat="item view/get_mime_types">
+                    <tr>
+                        <td>
+                            <img tal:attributes="src string:${here/portal_url}/${item/filename}" />
+                        </td>
+                        <td>
+                            <span tal:attributes="class item/classes" />
+                        </td>
+                        <td tal:content="item/normalized_name" />
+                    </tr>
+                </tal:MIMETYPE>
+
+            </tbody>
         </table>
 
     </div>

--- a/ftw/theming/configure.zcml
+++ b/ftw/theming/configure.zcml
@@ -50,4 +50,12 @@
         handler=".header.set_ftw_theming_header"
         />
 
+
+    <!-- override icons adapters, extend with a html wrapper tag -->
+    <adapter for="*
+                  ftw.theming.interfaces.IThemingLayer
+                  Products.ZCatalog.CatalogBrains.AbstractCatalogBrain"
+             factory=".icons.CatalogBrainContentIcon"
+             provides="plone.app.layout.icons.interfaces.IContentIcon" />
+
 </configure>

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -1,0 +1,28 @@
+from plone.app.layout.icons import icons
+from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.memoize.instance import memoize
+from zope.component import getUtility
+import os.path
+import re
+
+
+WRAPPER_TEMPLATE = '<span class="{classes}">{content}</span>'
+
+
+class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
+
+    @memoize
+    def html_tag(self):
+        image_tag = super(CatalogBrainContentIcon, self).html_tag()
+        if image_tag is None:
+            return None
+        return WRAPPER_TEMPLATE.format(classes=self.wrapper_classes(),
+                                       content=image_tag)
+
+    def wrapper_classes(self):
+        normalizer = getUtility(IIDNormalizer)
+        image_filename = os.path.basename(self.url)
+        image_filename = re.sub(r'\.png$', r'', image_filename)
+        mimetype_class = 'icon-mimetype-img-{}'.format(
+            normalizer.normalize(image_filename))
+        return 'mimetype-icon {}'.format(mimetype_class)

--- a/ftw/theming/resources/scss/base/standard_icons.scss
+++ b/ftw/theming/resources/scss/base/standard_icons.scss
@@ -8,3 +8,73 @@
 @include portal-type-font-awesome-icon(news-item, newspaper-o);
 @include portal-type-font-awesome-icon(plone-site, globe);
 @include portal-type-font-awesome-icon(topic, list-alt);
+
+
+@include mark-portal-type-having-mimetypes(file);
+
+/* Default */
+@include mime-type-font-awesome-icon(mime, file-o);
+@include mime-type-font-awesome-icon(application, file-o);
+@include mime-type-font-awesome-icon(unknown, file-o);
+
+/* ms office */
+@include mime-type-font-awesome-icon(doc, file-word-o);
+@include mime-type-font-awesome-icon(docx, file-word-o);
+@include mime-type-font-awesome-icon(xls, file-excel-o);
+@include mime-type-font-awesome-icon(xlsx, file-excel-o);
+@include mime-type-font-awesome-icon(ppt, file-powerpoint-o);
+@include mime-type-font-awesome-icon(pptx, file-powerpoint-o);
+
+/* open office */
+@include mime-type-font-awesome-icon(sxc, file-excel-o);
+@include mime-type-font-awesome-icon(sxd, file-image-o);
+@include mime-type-font-awesome-icon(sxi, file-powerpoint-o);
+@include mime-type-font-awesome-icon(sxm, file-excel-o);
+@include mime-type-font-awesome-icon(sxg, file-word-o);
+@include mime-type-font-awesome-icon(sxw, file-word-o);
+
+/* images */
+@include mime-type-font-awesome-icon(image, file-image-o);
+@include mime-type-font-awesome-icon(ps, file-image-o);
+@include mime-type-font-awesome-icon(png, file-image-o);
+
+/* archives */
+@include mime-type-font-awesome-icon(rar, file-archive-o);
+@include mime-type-font-awesome-icon(rpm, file-archive-o);
+@include mime-type-font-awesome-icon(tar, file-archive-o);
+@include mime-type-font-awesome-icon(zip, file-archive-o);
+@include mime-type-font-awesome-icon(deb, file-archive-o);
+@include mime-type-font-awesome-icon(iso, file-archive-o);
+@include mime-type-font-awesome-icon(pk, file-archive-o);
+
+/* media */
+@include mime-type-font-awesome-icon(audio, file-audio-o);
+@include mime-type-font-awesome-icon(midi, file-audio-o);
+@include mime-type-font-awesome-icon(wav, file-audio-o);
+@include mime-type-font-awesome-icon(video, file-video-o);
+@include mime-type-font-awesome-icon(avi, file-video-o);
+
+/* generic / various */
+@include mime-type-font-awesome-icon(dvi, file-o);
+@include mime-type-font-awesome-icon(pdf, file-pdf-o);
+@include mime-type-font-awesome-icon(txt, file-text-o);
+@include mime-type-font-awesome-icon(text, file-text-o);
+@include mime-type-font-awesome-icon(man, file-text-o);
+@include mime-type-font-awesome-icon(message, envelope-o);
+@include mime-type-font-awesome-icon(font, font);
+@include mime-type-font-awesome-icon(gf, font);
+@include mime-type-font-awesome-icon(vcard, user);
+
+/* code */
+@include mime-type-font-awesome-icon(sh, file-code-o);
+@include mime-type-font-awesome-icon(java, file-code-o);
+@include mime-type-font-awesome-icon(c, file-code-o);
+@include mime-type-font-awesome-icon(h, file-code-o);
+@include mime-type-font-awesome-icon(py, file-code-o);
+@include mime-type-font-awesome-icon(cpp, file-code-o);
+@include mime-type-font-awesome-icon(exe, file-code-o);
+@include mime-type-font-awesome-icon(f, file-code-o);
+@include mime-type-font-awesome-icon(o, file-code-o);
+@include mime-type-font-awesome-icon(html, file-code-o);
+@include mime-type-font-awesome-icon(pl, file-code-o);
+@include mime-type-font-awesome-icon(tex, file-code-o);

--- a/ftw/theming/resources/scss/default/theming_controlpanel.scss
+++ b/ftw/theming/resources/scss/default/theming_controlpanel.scss
@@ -43,3 +43,22 @@ body.template-theming-variables {
     }
   }
 }
+
+body.template-theming-icons {
+  .types-with-mimetype-icons-hint {
+    @extend .fa-icon;
+    @extend .fa-star;
+    &:before {
+      color: #A00;
+      font-size: 70%;
+      vertical-align: top;
+    }
+  }
+
+  .theming-mime-type-icons td {
+    text-align: center;
+    &:last-child {
+      text-align: left;
+    }
+  }
+}

--- a/ftw/theming/resources/scss/default_variables.scss
+++ b/ftw/theming/resources/scss/default_variables.scss
@@ -202,5 +202,7 @@ $screen-XXS: "(min-width: #{$mobile-tiny})" !default;
 /* ICONS */
 
 $standard-iconset: font-awesome;
+$use-font-awesome-mimetype-icons: true;
 @include declare-variables(
-  standard-iconset);
+  standard-iconset,
+  use-font-awesome-mimetype-icons);

--- a/ftw/theming/resources/scss/icon_mixins.scss
+++ b/ftw/theming/resources/scss/icon_mixins.scss
@@ -1,3 +1,6 @@
+
+/* Portal type icons registry */
+
 $icons-portal-type-icons: ();
 
 @mixin portal-type-icon($type, $value, $iconset) {
@@ -17,4 +20,40 @@ $icons-portal-type-icons: ();
 
 @mixin portal-type-font-awesome-icon($type, $value) {
   @include portal-type-icon($type, $value, font-awesome);
+}
+
+
+/* Portal types with mime type icons registry */
+$icons-mimetype-portal-types: ();
+
+@mixin mark-portal-type-having-mimetypes($type) {
+  $icons-mimetype-portal-types: append($icons-mimetype-portal-types, $type);
+}
+
+@function get-portal-types-with-mimetype-icons() {
+  @return $icons-mimetype-portal-types;
+}
+
+
+/* Mime type icons registry */
+
+$icons-mime-type-icons: ();
+
+@mixin mime-type-icon($classpostfix, $value, $iconset) {
+  $icons-mime-type-icons: append($icons-mime-type-icons,
+                                 ($classpostfix, $value, $iconset));
+}
+
+@function get-mime-type-icons-for-iconset($requested-iconset) {
+  $result: ();
+  @each $classpostfix, $value, $iconset in $icons-mime-type-icons {
+    @if $iconset == $requested-iconset {
+      $result: append($result, ($classpostfix, $value));
+    }
+  }
+  @return $result;
+}
+
+@mixin mime-type-font-awesome-icon($classpostfix, $value) {
+  @include mime-type-icon($classpostfix, $value, font-awesome);
 }

--- a/ftw/theming/resources/scss/iconset_font-awesome.scss
+++ b/ftw/theming/resources/scss/iconset_font-awesome.scss
@@ -26,18 +26,52 @@
   .icons-on [class^="contenttype-"],
   .icons-on [class*=" contenttype-"] {
     @extend .#{$fa-css-prefix}-times-circle;
-    @extend .fa-icon;
+    @extend .#{$fa-css-prefix}-icon;
     &:before {
       color: fuchsia;
     }
   }
 
   @each $type, $value in get-portal-type-icons-for-iconset(font-awesome) {
-    body.icons-on .contenttype-#{$type} {
+    body.icons-on .contenttype-$type {
       @extend .#{$fa-css-prefix}-#{$value};
       &:before {
         color: inherit;
       }
     }
+  }
+
+  @if $use-font-awesome-mimetype-icons == true {
+
+    @each $type in get-portal-types-with-mimetype-icons() {
+      .icons-on a.contenttype-$type:before {
+        display: none;
+      }
+
+      .icons-on #plone-contentmenu-factories a.contenttype-$type:before,
+      .icons-on.template-theming-icons a.contenttype-$type:before {
+        display: inline-block;
+      }
+      .icons-on.template-theming-icons a.contenttype-$type {
+        @extend .fa-icon-right;
+        &:after {
+          content: '\f005';
+          color: #A00;
+          font-size: 70%;
+          vertical-align: top;
+        }
+      }
+    }
+
+    @each $classpostfix, $value in get-mime-type-icons-for-iconset(font-awesome) {
+      body.icons-on span.mimetype-icon.icon-mimetype-img-$classpostfix {
+        >img {
+          display: none;
+        }
+        @extend .fa-icon;
+        @extend .#{$fa-css-prefix}-#{$value};
+      }
+    }
+
   }
 }

--- a/ftw/theming/tests/test_controlpanel.py
+++ b/ftw/theming/tests/test_controlpanel.py
@@ -73,3 +73,9 @@ class TestControlpanel(FunctionalTestCase):
         icons = browser.css('table.theming-portal-type-icons').first.dicts()
         self.assertIn({'Type': 'Folder',
                        'Name': 'folder'}, icons)
+
+    @browsing
+    def test_theming_icons_lists_mime_type_icons(self, browser):
+        browser.login(SITE_OWNER_NAME).open(view='theming-icons')
+        icons = browser.css('table.theming-mime-type-icons').first.dicts()
+        self.assertIn({'Name': 'pdf', 'Original': '', 'Icon': ''}, icons)

--- a/ftw/theming/tests/test_icons.py
+++ b/ftw/theming/tests/test_icons.py
@@ -1,0 +1,35 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.theming.tests import FunctionalTestCase
+
+
+class TestIconsAreWrapped(FunctionalTestCase):
+
+    @browsing
+    def test_navigation(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').titled(u'The Folder'))
+        create(Builder('file').titled(u'The File').with_dummy_content().within(folder))
+        create(Builder('navigation portlet'))
+
+        browser.open(folder)
+        navigation = browser.css('.portletNavigationTree')
+        file_linke_in_navigation = navigation.find('The File')
+        self.assertEquals(
+            ['mimetype-icon', 'icon-mimetype-img-doc'],
+            file_linke_in_navigation.css('span.mimetype-icon').first.classes)
+
+    @browsing
+    def test_folder_contents(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').titled(u'The Folder'))
+        create(Builder('file').titled(u'The File').with_dummy_content().within(folder))
+
+        browser.login().open(folder, view='folder_contents')
+        rows = browser.css('#listing-table').first.dicts(as_text=False, head_offset=1)
+        title_cell = rows[0][u'Title']
+        self.assertEquals(u'The File', title_cell.text)
+        self.assertEquals(
+            ['mimetype-icon', 'icon-mimetype-img-doc'],
+            title_cell.css('span.mimetype-icon').first.classes)


### PR DESCRIPTION
- extend Plone's `IContentIcon` adapter to return a `span`-wrapper where we can place the font-awesome-icon in a before
- add registry for icons and flag for portal-types which have mimetype icons (`File` only by default)
- add default icons
- show icons in controlpanel

**Result:**

Folder contents, navigation and factories-menu:
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 55 53" src="https://cloud.githubusercontent.com/assets/7469/10171750/ed769c94-66db-11e5-86e3-0d7311484e10.png">
--
Simplelayout file listing block with ftw.table (https://github.com/4teamwork/ftw.table/pull/40), Live search (https://github.com/OneGov/plonetheme.onegovbear/pull/68):
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 56 01" src="https://cloud.githubusercontent.com/assets/7469/10171759/f865107c-66db-11e5-9c9e-ef719bfb8ca5.png">
--
Control-Panel marks types which are known to have mimetypes:
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 56 19" src="https://cloud.githubusercontent.com/assets/7469/10171793/282d204c-66dc-11e5-8991-dd72fb6c6d41.png">
--
Control-Panel lists all mimetype icons in use:
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 56 22" src="https://cloud.githubusercontent.com/assets/7469/10171803/38007e1a-66dc-11e5-9861-d862b031a857.png">


