### PR TITLE
Remove duplicate icon in search results for files.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove duplicate icon in search results for files.
+  [jone]
 
 
 1.0.0 (2015-09-30)

--- a/ftw/theming/resources/scss/iconset_font-awesome.scss
+++ b/ftw/theming/resources/scss/iconset_font-awesome.scss
@@ -61,6 +61,12 @@
           vertical-align: top;
         }
       }
+
+      .icons-on.template-search .searchResults > .contenttype-$type {
+        &:before {
+          display: none;
+        }
+      }
     }
 
     @each $classpostfix, $value in get-mime-type-icons-for-iconset(font-awesome) {


### PR DESCRIPTION
The type icon is not necessary, the mimetype icon is sufficient.

**Before:**
<img width="1624" alt="bildschirmfoto 2015-10-21 um 09 08 46" src="https://cloud.githubusercontent.com/assets/7469/10629979/b25586ee-77d3-11e5-8cbf-650355b183b6.png">
--
**After:**
<img width="1624" alt="bildschirmfoto 2015-10-21 um 09 09 02" src="https://cloud.githubusercontent.com/assets/7469/10629978/b252aadc-77d3-11e5-9c70-696ce62a1488.png">