### PR TITLE
`width-full` functional class for grid system is not available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Add `width-full` functional class of grid system for legacy support.
+  [Kevin Bieri]
+
 - Introduce floated grid system.
   [Kevin Bieri]
 

--- a/ftw/theming/resources/scss/globals/grid.scss
+++ b/ftw/theming/resources/scss/globals/grid.scss
@@ -85,3 +85,7 @@ $gridsystem-width: $columns * $column-width + ($columns - 1) * $gutter-width + 2
 .cell {
   @include cell();
 }
+
+.width-full {
+  @include gridwidth($columns);
+}


### PR DESCRIPTION
Fixes https://github.com/OneGov/plonetheme.onegovbear/issues/109

Add `width-full` functional class of deco grid system for legacy support.

![bildschirmfoto 2016-02-03 um 08 56 57](https://cloud.githubusercontent.com/assets/1637820/12776172/1a0c084e-ca54-11e5-9af8-4c0686600704.png)