### PR TITLE
Limit the row in its height.

### DIFF
--- a/ftw/theming/resources/scss/globals/grid.scss
+++ b/ftw/theming/resources/scss/globals/grid.scss
@@ -72,8 +72,10 @@ $gridsystem-width: $columns * $column-width + ($columns - 1) * $gutter-width + 2
 }
 
 @mixin row {
-  float: left;
+  @include clearfix();
   width: 100%;
+  max-width: $max-width-page;
+  margin: 0 auto;
   display: block;
   position: relative;
 }


### PR DESCRIPTION
The inserted clearfix has the same effect as floating left.
The row should also limit in its height to match the page layout.