### PR TITLE
The link color is not visible on some background.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Introduce inverted link colors.
+  Apply blueberry color scheme.
+  [Kevin Bieri]
+
 - Update font-awesome to 4.5.0. [jone]
 
 - Add `width-full` functional class of grid system for legacy support.

--- a/ftw/theming/resources/scss/globals/variables.scss
+++ b/ftw/theming/resources/scss/globals/variables.scss
@@ -2,8 +2,8 @@
   Colors
  */
 
-$color-primary: #3498db !default;
-$color-secondary: #46637f !default;
+$color-primary: #3B234A !default;
+$color-secondary: #BAAFC4 !default;
 $color-edit: #75ad0a !default;
 
 $color-default: #2980b9 !default;

--- a/ftw/theming/resources/scss/globals/variables.scss
+++ b/ftw/theming/resources/scss/globals/variables.scss
@@ -21,6 +21,8 @@ $color-text-light: #95a5a6 !default;
 
 $color-link: $color-primary !default;
 $color-link-hover: $color-secondary !default;
+$color-link-inverted: $color-primary !default;
+$color-link-hover-inverted: $color-text-inverted !default;
 
 $color-disabled: $color-gray-light !default;
 $color-text-disabled: $color-gray-dark !default;
@@ -89,6 +91,8 @@ $line-height-base: 1.2em !default;
   color-text-light,
   color-link,
   color-link-hover,
+  color-link-inverted,
+  color-link-hover-inverted,
   color-disabled,
   color-text-disabled,
   font-weight-link,

--- a/ftw/theming/tests/test_controlpanel.py
+++ b/ftw/theming/tests/test_controlpanel.py
@@ -57,7 +57,7 @@ class TestControlpanel(FunctionalTestCase):
 
         self.assertIn({'File': 'variables.scss',
                        'Name': '$color-primary',
-                       'Value': '#3498db',
+                       'Value': '#3B234A',
                        'Example': ''},
                       variables)
 


### PR DESCRIPTION
On some backgrounds (colored) the default link color is not visible. So introduce an inverted link color which will be used on colored backgrounds.

Change the default color scheme to a more blueberry styling scheme because the main theme is plonetheme.blueberry.

Example of the plueberry.theme

![bildschirmfoto 2016-02-15 um 11 27 13](https://cloud.githubusercontent.com/assets/1637820/13046082/1f30db4c-d3d7-11e5-8351-e37c6f507ccc.png)
