### PR TITLE
Register available scales in dynamic SCSS file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- Register imaging scales as dynamic SCSS resource.
+  [Kevin Bieri]
+
 - Introduce inverted link colors.
   Apply blueberry color scheme.
   [Kevin Bieri]

--- a/ftw/theming/resources.zcml
+++ b/ftw/theming/resources.zcml
@@ -4,6 +4,7 @@
     i18n_domain="ftw.theming">
 
     <theme:scss_factory factory=".variables.portal_url_variable_resource_factory" />
+    <theme:scss_factory factory=".variables.plone_image_sizes" />
 
     <theme:scss file="resources/scss/core.scss" slot="top" />
 

--- a/ftw/theming/tests/test_variables.py
+++ b/ftw/theming/tests/test_variables.py
@@ -17,3 +17,38 @@ class TestVariables(FunctionalTestCase):
                           resource.get_source(self.portal, self.request).strip())
 
         self.assertEquals('variables', resource.slot)
+
+    def test_plone_image_sizes(self):
+        registry = getUtility(ISCSSRegistry)
+        resources = dict((res.name, res)
+                         for res in registry.get_resources(self.portal, self.request))
+        self.assertIn('ftw.theming:image_sizes', resources.keys())
+
+        resource = resources['ftw.theming:image_sizes']
+        self.assertEquals('variables', resource.slot)
+
+        self.maxDiff = None
+
+        self.assertEqual((
+            '$scale-mini-width: 200px;'
+            '$scale-mini-height: 200px;'
+            '@include declare-variables(scale-width-mini, scale-height-mini);'
+            '$scale-thumb-width: 128px;'
+            '$scale-thumb-height: 128px;'
+            '@include declare-variables(scale-width-thumb, scale-height-thumb);'
+            '$scale-large-width: 768px;'
+            '$scale-large-height: 768px;'
+            '@include declare-variables(scale-width-large, scale-height-large);'
+            '$scale-listing-width: 16px;'
+            '$scale-listing-height: 16px;'
+            '@include declare-variables(scale-width-listing, scale-height-listing);'
+            '$scale-tile-width: 64px;'
+            '$scale-tile-height: 64px;'
+            '@include declare-variables(scale-width-tile, scale-height-tile);'
+            '$scale-preview-width: 400px;'
+            '$scale-preview-height: 400px;'
+            '@include declare-variables(scale-width-preview, scale-height-preview);'
+            '$scale-icon-width: 32px;'
+            '$scale-icon-height: 32px;'
+            '@include declare-variables(scale-width-icon, scale-height-icon);'
+            ), resource.get_source(self.portal, self.request).strip())

--- a/ftw/theming/variables.py
+++ b/ftw/theming/variables.py
@@ -1,6 +1,8 @@
 from ftw.theming.interfaces import ISCSSResourceFactory
 from ftw.theming.resource import DynamicSCSSResource
+from plone.namedfile.interfaces import IAvailableSizes
 from Products.CMFCore.utils import getToolByName
+from zope.component import queryUtility
 from zope.interface import provider
 import hashlib
 
@@ -12,6 +14,31 @@ def portal_url_variable_resource_factory(context, request):
     return DynamicSCSSResource(
         'ftw.theming:portal_url', slot='variables',
         source=u'\n'.join((
-                u'$portal-url: "{0}";'.format(portal_url),
-                u'@include declare-variables(portal-url);')),
+               u'$portal-url: "{0}";'.format(portal_url),
+               u'@include declare-variables(portal-url);')),
+        cachekey=cachekey)
+
+
+@provider(ISCSSResourceFactory)
+def plone_image_sizes(context, request):
+    sass_variables_template = (
+        '$scale-{name}-width: {width}px;'
+        '$scale-{name}-height: {height}px;'
+        '@include declare-variables(scale-width-{name}, scale-height-{name});'
+        )
+    getAvailableSizes = queryUtility(IAvailableSizes)
+    sizes = getAvailableSizes()
+
+    def build_sass_map(size):
+        width, height = size[1]
+        name = size[0]
+        return sass_variables_template.format(
+            name=name, width=width, height=height)
+
+    cachekey = hashlib.md5(str(sorted(sizes.values()))).hexdigest()
+    sizes = map(build_sass_map, sizes.iteritems())
+
+    return DynamicSCSSResource(
+        'ftw.theming:image_sizes', slot='variables',
+        source=u''.join(sizes),
         cachekey=cachekey)


### PR DESCRIPTION
All available scales from the properties are stored in a
dynamic SCSS file.
Each scale is stored as a variable with the name of the scale.
Each variable stores a map with the dimensions.