### PR TITLE
General Improvements

### DIFF
--- a/ftw/theming/resources/scss/elements/list.scss
+++ b/ftw/theming/resources/scss/elements/list.scss
@@ -14,7 +14,7 @@ $color-list-hover: $color-gray-light !default;
 
     > a {
       display: block;
-      padding: $padding-vertical $padding-horizontal;
+      padding: $padding-vertical $padding-horizontal / 2;
     }
   }
 }

--- a/ftw/theming/resources/scss/elements/tab.scss
+++ b/ftw/theming/resources/scss/elements/tab.scss
@@ -7,7 +7,7 @@ $color-tab-hover: $color-tab-select !default;
   @include no-link();
 
   padding: $padding-vertical $padding-horizontal;
-  background-color: $color-white;
+  background-color: $color-content-background;
   color: $color-text;
   position: relative;
 


### PR DESCRIPTION
- Reduce spacing between horizontally aligned list items.
Because the list items have the standard spacing on both sides the space
between horizontally aligned list items is doubled. So use the half of the spacing.

- Tab default background should be equal to the content background.