### PR TITLE
Adjust overlay size for large and small overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Introduce overlay mixin.
+  [Kevin Bieri]
+
 - Extend floatgrid with by-index directive.
   [Kevin Bieri]
 

--- a/ftw/theming/resources/scss/elements/overlay.scss
+++ b/ftw/theming/resources/scss/elements/overlay.scss
@@ -38,20 +38,10 @@
   @include overlay-full();
 
   @include screen-small {
-    top: $margin-vertical * 5 !important;
-    bottom: $margin-vertical * 5 !important;
-    right: 5% !important;
-    left: 5% !important;
-  }
-
-  @include screen-medium {
-    right: 10% !important;
-    left: 10% !important;
-  }
-
-  @include screen-large {
-    right: 15% !important;
-    left: 15% !important;
+    top: 2% !important;
+    bottom: 2% !important;
+    right: 2% !important;
+    left: 2% !important;
   }
 }
 
@@ -81,7 +71,7 @@
 
   @include screen-small {
     top: $margin-vertical * 5 !important;
-    height: 40% !important;
+    height: 400px !important;
     right: 20% !important;
     left: 20% !important;
   }


### PR DESCRIPTION
According to https://github.com/4teamwork/plonetheme.blueberry/pull/52#issuecomment-214168577
the large overlay is too small. So we decided to make the large overlay
almost fullscreen so that the user is still able to see a bit of the
page in the transparent background.

The large overlay does not scale the size until the mobile breakpoint has been
reached.

The small overlay is too small on tiny screen becuase the height is relative to the
screensize. So we dediced to set a fixed height so that the user is still able
to see the content of the overlay on tiny screens.
We height is based on the plone login form and the simplelayout delete confirmation.