### PR TITLE
Reduce tab hover state

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Reduce tab hover state
+  The current hover state will be always the selected state
+  [Kevin Bieri]
 
 
 1.6.0 (2016-07-18)

--- a/ftw/theming/resources/scss/elements/tab.scss
+++ b/ftw/theming/resources/scss/elements/tab.scss
@@ -1,8 +1,7 @@
 $color-tab: $color-gray-dark !default;
 $color-tab-select: $color-primary !default;
-$color-tab-hover: $color-tab-select !default;
 
-@mixin tab($color-tab: $color-tab) {
+@mixin tab($color-tab: $color-tab, $color-tab-select: $color-tab-select) {
 
   @include no-link();
 
@@ -22,14 +21,14 @@ $color-tab-hover: $color-tab-select !default;
   }
 
   &:hover:before {
-    background-color: $color-tab-hover;
+    background-color: $color-tab-select;
   }
 
 
 }
 
 @mixin tab-select($color-tab-select: $color-tab-select) {
-  @include tab($color-tab-select);
+  @include tab($color-tab: $color-tab-select, $color-tab-select: $color-tab-select);
 }
 
 @mixin tab-list($color-tab: $color-tab, $color-tab-select: $color-tab-select) {
@@ -70,7 +69,7 @@ $color-tab-hover: $color-tab-select !default;
 
 
     > a {
-      @include tab($color-tab);
+      @include tab($color-tab, $color-tab-select);
     }
   }
 


### PR DESCRIPTION
The tab hover state will now always be the selected state.