### PR TITLE
Fix error `ERROR scss.ast Function not found: circle` in pyScss

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -2,3 +2,7 @@
 extends =
     test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+
+auto-checkout +=
+# https://github.com/Kronuz/pyScss/pull/357
+    pyScss


### PR DESCRIPTION
Use pyScss from source to get rid of
`ERROR scss.ast Function not found: circle` error which has been fixed
through https://github.com/Kronuz/pyScss/pull/357

@jone tested with winterthur