### PR TITLE
add an expandicon on colorbox images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.mo
 *.pyc
+.DS_Store
 .installed.cfg
 .mr.developer.cfg
 README.html

--- a/ftw/theming/resources/scss/iconset_font-awesome.scss
+++ b/ftw/theming/resources/scss/iconset_font-awesome.scss
@@ -30,6 +30,25 @@
     }
   }
 
+  .icons-on .sl-image .colorboxLink{
+    @extend .#{$fa-css-prefix}-expand;
+    @extend .#{$fa-css-prefix}-icon;
+    &:before {
+    color: white;
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    font-size: 1.5em;
+    background: rgb(0,0,0);
+    opacity: 0.5;
+    border-radius: 2px;
+    padding: 2px 0px 1px 0px;
+   }
+   &:hover:before {
+        opacity: 1;
+   }
+  }
+
   @each $type, $value in get-portal-type-icons-for-iconset(font-awesome) {
     body.icons-on .contenttype-$type {
       @extend .#{$fa-css-prefix}-#{$value};


### PR DESCRIPTION
Requires ftw.simplelayout#358.

This PR adds a icon making it visible if a image can be viewed in colorbox or not.

![screen shot 2016-08-09 at 08 52 09](https://cloud.githubusercontent.com/assets/358342/17507541/721ef564-5e10-11e6-965a-7add1170963f.png)

also i added .ds_store files to the gitignore.