### PR TITLE
🚧 🚧  Disable standard CSS resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,97 @@ SCSS resources and the default SCSS variables.
 The controlpanel views are available on any navigation root.
 
 
+Disable standard CSS resources
+==============================
+
+When building a new theme with ``ftw.theming``, we often want to replace
+existing CSS shipped by Plone or addon packages completely and therefore not
+have those CSS resources loaded at all.
+We want to exclude certain resources registered in ``portal_css`` if "our"
+theme is active.
+We should not modify the existing resources though, in order to be able to
+switch between multiple Diazo themes which may have a different configuration.
+
+For solving this problem ``ftw.theming`` extends the resource registry so that
+we can disable certain resoures for a specific Diazo theme.
+This disabling mechanism precedes other conditions such as the "expression" or
+the "authenticated" condition.
+
+
+Disable CSS resources
+---------------------
+
+Disabling CSS resources is done through ZCML:
+
+.. code:: xml
+
+    <configure
+        xmlns:theme="http://namespaces.zope.org/ftw.theming"
+        xmlns:zcml="http://namespaces.zope.org/zcml"
+        i18n_domain="plonetheme.vintage">
+
+        <include package="ftw.theming" />
+
+        <theme:portal_css theme="plonetheme.vintage">
+            <theme:disable_resource id="public.css" />
+            <theme:disable_resource id="authoring.css" />
+            <theme:disable_resource id="++resource++quickupload_static/uploadify.css" />
+        </theme:portal_css>
+
+    </configure>
+
+The CSS resources do not have to be registered in ``portal_css`` yet.
+This allows us to support extras-dependencies.
+
+
+Re-enabled CSS resources
+------------------------
+
+A disabled CSS resource can later be re-enabled, but make sure that the ZCML load
+order is correct by ``<include>``-ing the ZCML which disables the resource:
+
+.. code:: xml
+
+    <configure
+        xmlns:theme="http://namespaces.zope.org/ftw.theming"
+        xmlns:zcml="http://namespaces.zope.org/zcml"
+        i18n_domain="my.app">
+
+        <include package="ftw.theming" />
+
+        <!-- re-enable public.css because of important reasons -->
+        <include package="plonetheme.vintage" />
+        <theme:portal_css theme="plonetheme.vintage">
+            <theme:enable_resource id="public.css" />
+        </theme:portal_css>
+
+    </configure>
+
+
+Disable all Plone standard CSS resources
+----------------------------------------
+
+It is possible to disable all Plone standard CSS resources at once.
+This disables all CSS resources which are registered when installing a fresh
+Plone without dependencies.
+
+.. code:: xml
+
+    <configure
+        xmlns:theme="http://namespaces.zope.org/ftw.theming"
+        xmlns:zcml="http://namespaces.zope.org/zcml"
+        i18n_domain="my.app">
+
+        <include package="ftw.theming" />
+
+        <include package="plonetheme.vintage" />
+        <theme:portal_css theme="plonetheme.vintage">
+            <theme:disable_plone_css_resources />
+        </theme:portal_css>
+
+    </configure>
+
+
 Icons
 =====
 

--- a/ftw/theming/configure.zcml
+++ b/ftw/theming/configure.zcml
@@ -2,12 +2,14 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:theme="http://namespaces.zope.org/ftw.theming"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.theming">
 
     <include package="ftw.upgrade" file="meta.zcml" />
+    <include package="collective.monkeypatcher" />
 
     <utility factory=".resource_disabler.ResourceDisablerConfig" />
 
@@ -17,6 +19,14 @@
     <include package=".viewlets" />
 
     <browser:resourceDirectory name="ftw.theming" directory="resources" />
+
+    <monkey:patch
+        description="Hook into portal_css expression evaulation in order to disable CSS resources depending on activated theme."
+        class="Products.ResourceRegistries.tools.CSSRegistry.CSSRegistryTool"
+        original="evaluate"
+        replacement=".patches.CSSRegistryTool_evaluate"
+        preserveOriginal="True"
+        />
 
     <adapter factory=".compiler.SCSSCompiler" />
 

--- a/ftw/theming/configure.zcml
+++ b/ftw/theming/configure.zcml
@@ -9,6 +9,8 @@
 
     <include package="ftw.upgrade" file="meta.zcml" />
 
+    <utility factory=".resource_disabler.ResourceDisablerConfig" />
+
     <include file="meta.zcml" />
     <include file="resources.zcml" />
     <include package=".browser" />

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -242,3 +242,38 @@ class ISCSSResourceFactory(Interface):
 class ICSSCaching(Interface):
     """Marker interface for enabling plone.app.caching on the theming resource.
     """
+
+
+class IResourceDisablerConfig(Interface):
+    """The resource disabler config holds information about which standard
+    portal_css resource should be disabled for which theme.
+    The resource disabler config is filled by using ZCML statements for each
+    theme.
+    The config can then be asked whether a resource should be enabled when a
+    specific theme is active.
+    """
+
+    def add_css_resource(resource_id, theme_name, enabled):
+        """Let the config know whether a portal_css resource should be enabled
+        for a speicific theme.
+
+        :param resource_id: The id of the resource as registered in portal_css.
+        :type resource_id: string
+        :param theme_id: Theme as declared in the `theme.xml`.
+        :type theme_id: string
+        :param enabled: Whether the resource should be enabled or disabled
+        for this theme.
+        :type enabled: boolean
+        """
+
+    def is_css_resource_enabled(resource_id, theme_name):
+        """Returns whether a css resource is enabled for the current theme.
+
+        :param resource_id: The id of the resource as registered in portal_css.
+        :type resource_id: string
+        :param theme_id: Theme as declared in the `theme.xml`.
+        :type theme_id: string
+        :returns: Whether the resource should be enabled or disabled
+        for this theme.
+        :rtype: boolean
+        """

--- a/ftw/theming/meta.zcml
+++ b/ftw/theming/meta.zcml
@@ -28,6 +28,28 @@
 
         </meta:complexDirective>
 
+        <meta:complexDirective
+            name="portal_css"
+            schema=".meta.IResourceRegistryGroupDirective"
+            handler=".meta.PortalCSS">
+
+            <meta:subdirective
+                name="disable_resource"
+                schema=".meta.IResourceDirective"
+                />
+
+            <meta:subdirective
+                name="enable_resource"
+                schema=".meta.IResourceDirective"
+                />
+
+            <meta:subdirective
+                name="disable_plone_css_resources"
+                schema="zope.interface.Interface"
+                />
+
+        </meta:complexDirective>
+
     </meta:directives>
 
 </configure>

--- a/ftw/theming/patches.py
+++ b/ftw/theming/patches.py
@@ -1,0 +1,18 @@
+from ftw.theming.interfaces import IResourceDisablerConfig
+from plone.app.theming import utils
+from zope.component import getUtility
+
+
+def CSSRegistryTool_evaluate(self, item, context):
+    """Evaluate an object to see if it should be displayed.
+    PATCH: let ftw.theming exclude resources.
+    """
+
+    if utils.isThemeEnabled(context.REQUEST):
+        config = getUtility(IResourceDisablerConfig)
+        theme_name = utils.getCurrentTheme()
+        resource_id = item.getId()
+        if not config.is_css_resource_enabled(resource_id, theme_name):
+            return False
+
+    return self._old_evaluate(item, context)

--- a/ftw/theming/profiles/base/cssregistry.xml
+++ b/ftw/theming/profiles/base/cssregistry.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_css">
-
-    <!-- Disable Plone standard CSS when ftw.theming is active with this profile,
-         since the SCSS-resources registered with this profile replace those CSS. -->
-    <!-- <stylesheet id="reset.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" /> -->
-
-</object>

--- a/ftw/theming/resource_disabler.py
+++ b/ftw/theming/resource_disabler.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+from ftw.theming.interfaces import IResourceDisablerConfig
+from zope.interface import implements
+
+
+PLONE_RESOURCES = (
+    '++resource++plone.app.discussion.stylesheets/discussion.css',
+    '++resource++plone.app.jquerytools.dateinput.css',
+    '++resource++plone.app.jquerytools.overlays.css',
+    '++resource++tinymce.stylesheets/tinymce.css',
+    'IEFixes.css',
+    'RTL.css',
+    'authoring.css',
+    'base.css',
+    'bbb-kss.css',
+    'columns.css',
+    'controlpanel.css',
+    'deprecated.css',
+    'forms.css',
+    'invisibles.css',
+    'member.css',
+    'mobile.css',
+    'navtree.css',
+    'portlets.css',
+    'print.css',
+    'public.css',
+    'reset.css',
+
+    # ploneCustom.css is empty by default and can be used for TTW customizations,
+    # therefore we should not disable it by default.
+    # 'ploneCustom.css',
+)
+
+
+class ResourceDisablerConfig(object):
+    implements(IResourceDisablerConfig)
+
+    def __init__(self):
+        self.reset()
+
+    def add_css_resource(self, resource_id, theme_name, enabled):
+        self.resources['portal_css'][theme_name][resource_id] = enabled
+
+    def is_css_resource_enabled(self, resource_id, theme_name):
+        return self.resources['portal_css'][theme_name].get(resource_id, True)
+
+    def disable_plone_resources(self, theme_name):
+        for resource_id in PLONE_RESOURCES:
+            self.add_css_resource(resource_id, theme_name, enabled=False)
+
+    def reset(self):
+        self.resources = {'portal_css': defaultdict(dict)}

--- a/ftw/theming/testing.py
+++ b/ftw/theming/testing.py
@@ -32,6 +32,7 @@ class ThemingLayer(PloneSandboxLayer):
             '  <include package="z3c.autoinclude" file="meta.zcml" />'
             '  <includePlugins package="plone" />'
             '  <includePluginsOverrides package="plone" />'
+            '  <include package="ftw.theming.tests.vintagetheme" />'
             '</configure>',
             context=configurationContext)
 

--- a/ftw/theming/tests/test_disable_css_resources.py
+++ b/ftw/theming/tests/test_disable_css_resources.py
@@ -1,0 +1,95 @@
+from ftw.testbrowser import browser
+from ftw.testbrowser import browsing
+from ftw.theming.interfaces import IResourceDisablerConfig
+from ftw.theming.tests import FunctionalTestCase
+from plone.app.testing import applyProfile
+from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
+import transaction
+
+
+class TestDisableCSSResources(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDisableCSSResources, self).setUp()
+        applyProfile(self.portal, 'ftw.theming.tests.vintagetheme:default')
+        getToolByName(self.portal, 'portal_css').setDebugMode(True)
+        transaction.commit()
+        getUtility(IResourceDisablerConfig).reset()
+
+    @browsing
+    def test_disable_css_resource(self, browser):
+        browser.open()
+        self.assertTrue(self.get_css_url('public.css'))
+        self.load_zcml(
+            '<theme:portal_css theme="ftw.theming.tests.vintagetheme">'
+            '  <theme:disable_resource id="public.css" />'
+            '</theme:portal_css>')
+        browser.reload()
+        self.assertFalse(self.get_css_url('public.css'))
+
+    @browsing
+    def test_reenable_css_resource(self, browser):
+        self.load_zcml(
+            '<theme:portal_css theme="ftw.theming.tests.vintagetheme">'
+            '  <theme:disable_resource id="public.css" />'
+            '</theme:portal_css>')
+        browser.open()
+        self.assertFalse(self.get_css_url('public.css'))
+
+        self.load_zcml(
+            '<theme:portal_css theme="ftw.theming.tests.vintagetheme">'
+            '  <theme:enable_resource id="public.css" />'
+            '</theme:portal_css>')
+        browser.reload()
+        self.assertTrue(self.get_css_url('public.css'))
+
+    @browsing
+    def test_disable_plone_resources(self, browser):
+        browser.open()
+        self.assertTrue(self.get_css_url('public.css'))
+
+        self.load_zcml(
+            '<theme:portal_css theme="ftw.theming.tests.vintagetheme">'
+            '  <theme:disable_plone_css_resources />'
+            '</theme:portal_css>')
+        browser.reload()
+        self.assertFalse(self.get_css_url('public.css'))
+
+    @browsing
+    def test_disabling_is_theme_sepcific(self, browser):
+        # The theme "ftw.theming.tests.vintagetheme" is active.
+        browser.open()
+        self.assertTrue(self.get_css_url('public.css'))
+        self.assertTrue(self.get_css_url('authoring.css'))
+
+        self.load_zcml(
+            '<theme:portal_css theme="ftw.theming.tests.vintagetheme">'
+            '  <theme:disable_resource id="public.css" />'
+            '</theme:portal_css>'
+            '<theme:portal_css theme="plonetheme.fancy">'
+            '  <theme:disable_resource id="auuthoring.css" />'
+            '</theme:portal_css>')
+        browser.reload()
+        self.assertFalse(self.get_css_url('public.css'))
+        self.assertTrue(self.get_css_url('authoring.css'))
+
+    def load_zcml(self, *lines):
+        self.layer['load_zcml_string']('\n'.join((
+            '<configure ',
+            '    xmlns:theme="http://namespaces.zope.org/ftw.theming"',
+            '    i18n_domain="my.package"',
+            '    package="ftw.theming.tests"''>',
+        ) + lines + (
+            '</configure>',
+        )))
+
+    def list_css_urls(self):
+        return [node.attrib.get('href') for node in browser.css('link')]
+
+    def get_css_url(self, url_end):
+        for url in self.list_css_urls():
+            if url.endswith(url_end):
+                return url
+
+        return None

--- a/ftw/theming/tests/test_resource_disabler_config.py
+++ b/ftw/theming/tests/test_resource_disabler_config.py
@@ -1,0 +1,33 @@
+from ftw.theming.interfaces import IResourceDisablerConfig
+from unittest2 import TestCase
+from ftw.theming.resource_disabler import ResourceDisablerConfig
+from zope.interface.verify import verifyObject
+
+
+class TestResourceDisablerConfig(TestCase):
+
+    def test_implements_interface(self):
+        config = ResourceDisablerConfig()
+        verifyObject(IResourceDisablerConfig, config)
+
+    def test_css_resource_enabled_by_default(self):
+        config = ResourceDisablerConfig()
+        self.assertTrue(config.is_css_resource_enabled('public.css', 'darktheme'))
+
+    def test_disable_css_resource_for_theme(self):
+        config = ResourceDisablerConfig()
+        config.add_css_resource('public.css', 'darktheme', enabled=False)
+        self.assertFalse(config.is_css_resource_enabled('public.css', 'darktheme'))
+        self.assertTrue(config.is_css_resource_enabled('public.css', 'lighttheme'))
+        config.add_css_resource('public.css', 'darktheme', enabled=True)
+        self.assertTrue(config.is_css_resource_enabled('public.css', 'darktheme'))
+
+    def test_disable_plone_resources(self):
+        config = ResourceDisablerConfig()
+        self.assertTrue(config.is_css_resource_enabled('public.css', 'vintage'))
+        self.assertTrue(config.is_css_resource_enabled('my.project.css', 'vintage'))
+
+        config.disable_plone_resources('vintage')
+        self.assertFalse(config.is_css_resource_enabled('public.css', 'vintage'))
+        self.assertFalse(config.is_css_resource_enabled('authoring.css', 'vintage'))
+        self.assertTrue(config.is_css_resource_enabled('my.project.css', 'vintage'))

--- a/ftw/theming/tests/test_resource_disabler_directives.py
+++ b/ftw/theming/tests/test_resource_disabler_directives.py
@@ -1,0 +1,77 @@
+from ftw.theming.interfaces import IResourceDisablerConfig
+from ftw.theming.testing import META_ZCML
+from unittest2 import TestCase
+from zope.component import getUtility
+
+
+class TestResourceDisablerDirectives(TestCase):
+    layer = META_ZCML
+
+    def setUp(self):
+        self.layer.load_zcml_string(
+            '<configure xmlns="http://namespaces.zope.org/zope"'
+            '           package="ftw.theming">'
+            '  <utility factory=".resource_disabler.ResourceDisablerConfig" />'
+            '</configure>')
+
+    def test_disable_specific_css_resource(self):
+        self.assert_enabled_css_resources(
+            {'public.css': True, 'editing.css': True},
+            'plonetheme.vintage')
+
+        self.load_zcml(
+            '<theme:portal_css theme="plonetheme.vintage">'
+            '  <theme:disable_resource id="public.css" />'
+            '</theme:portal_css>')
+
+        self.assert_enabled_css_resources(
+            {'public.css': False, 'editing.css': True},
+            'plonetheme.vintage')
+
+    def test_renable_specific_css_resource(self):
+        self.load_zcml(
+            '<theme:portal_css theme="plonetheme.vintage">'
+            '  <theme:disable_resource id="public.css" />'
+            '</theme:portal_css>')
+
+        self.assert_enabled_css_resources(
+            {'public.css': False, 'editing.css': True},
+            'plonetheme.vintage')
+
+        self.load_zcml(
+            '<theme:portal_css theme="plonetheme.vintage">'
+            '  <theme:enable_resource id="public.css" />'
+            '</theme:portal_css>')
+
+        self.assert_enabled_css_resources(
+            {'public.css': True, 'editing.css': True},
+            'plonetheme.vintage')
+
+    def test_disable_all_plone_resources(self):
+        self.load_zcml(
+            '<theme:portal_css theme="plonetheme.vintage">'
+            '  <theme:disable_plone_css_resources />'
+            '</theme:portal_css>')
+
+        self.assert_enabled_css_resources(
+            {'base.css': False,
+             'reset.css': False,
+             '++resource++quickupload_static/uploadify.css': True},
+            'plonetheme.vintage')
+
+    def assert_enabled_css_resources(self, expected, theme_name):
+        config = getUtility(IResourceDisablerConfig)
+        got = {resource_id: config.is_css_resource_enabled(resource_id,
+                                                           theme_name)
+                for resource_id in expected.keys()}
+        self.assertEquals(expected, got)
+
+    def load_zcml(self, *lines):
+        self.layer.load_zcml_string('\n'.join((
+            '<configure ',
+            '    xmlns:theme="http://namespaces.zope.org/ftw.theming"',
+            '    i18n_domain="my.package"',
+            '    package="ftw.theming.tests"''>',
+        ) + lines + (
+            '</configure>',
+        )))

--- a/ftw/theming/tests/vintagetheme/configure.zcml
+++ b/ftw/theming/tests/vintagetheme/configure.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.theming.tests.vintagetheme">
+
+    <plone:static type="theme" directory="theme" />
+
+    <genericsetup:registerProfile
+        name="default"
+        title="ftw.theming.tests.vintagetheme"
+        directory="profiles/default"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/ftw/theming/tests/vintagetheme/profiles/default/metadata.xml
+++ b/ftw/theming/tests/vintagetheme/profiles/default/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-plone.app.theming:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/theming/tests/vintagetheme/profiles/default/theme.xml
+++ b/ftw/theming/tests/vintagetheme/profiles/default/theme.xml
@@ -1,0 +1,4 @@
+<theme>
+    <name>ftw.theming.tests.vintagetheme</name>
+    <enabled>true</enabled>
+</theme>

--- a/ftw/theming/tests/vintagetheme/theme/index.html
+++ b/ftw/theming/tests/vintagetheme/theme/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="en"></html>

--- a/ftw/theming/tests/vintagetheme/theme/manifest.cfg
+++ b/ftw/theming/tests/vintagetheme/theme/manifest.cfg
@@ -1,0 +1,2 @@
+[theme]
+title = ftw.theming.tests.vintagetheme

--- a/ftw/theming/tests/vintagetheme/theme/rules.xml
+++ b/ftw/theming/tests/vintagetheme/theme/rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <theme href="/++theme++ftw.theming.tests.vintagetheme/index.html" />
+    <replace css:content="html" css:theme="html" />
+
+</rules>

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='ftw.theming',
           'six >= 1.4.0',  # six.unichr
           'setuptools',
           'tarjan',
+          'collective.monkeypatcher',
       ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),


### PR DESCRIPTION
When building a new theme with `ftw.theming`, we often want to replace existing CSS shipped by Plone or addon packages completely and therefore not have those CSS resources loaded at all.
We want to exclude certain resources registered in `portal_css` if "our" theme is active.
We should not modify the existing resources though, in order to be able to switch between multiple Diazo themes which may have a different configuration.

For solving this problem `ftw.theming` extends the resource registry so that we can disable certain resoures for a specific Diazo theme.
This disabling mechanism precedes other conditions such as the "expression" or the "authenticated" condition.
### Disable CSS resources

Disabling CSS resources is done through ZCML:

``` xml
    <configure
        xmlns:theme="http://namespaces.zope.org/ftw.theming"
        xmlns:zcml="http://namespaces.zope.org/zcml"
        i18n_domain="plonetheme.vintage">

        <include package="ftw.theming" />

        <theme:portal_css theme="plonetheme.vintage">
            <theme:disable_resource id="public.css" />
            <theme:disable_resource id="authoring.css" />
            <theme:disable_resource id="++resource++quickupload_static/uploadify.css" />
        </theme:portal_css>

    </configure>
```

The CSS resources do not have to be registered in `portal_css` yet. This allows us to support extras-dependencies.
### Re-enabled CSS resources

A disabled CSS resource can later be re-enabled, but make sure that the ZCML load
order is correct by `<include>`-ing the ZCML which disables the resource:

``` xml
    <configure
        xmlns:theme="http://namespaces.zope.org/ftw.theming"
        xmlns:zcml="http://namespaces.zope.org/zcml"
        i18n_domain="my.app">

        <include package="ftw.theming" />

        <!-- re-enable authoring.css because of important reasons -->
        <include package="plonetheme.vintage" />
        <theme:portal_css theme="plonetheme.vintage">
            <theme:enable_resource id="public.css" />
        </theme:portal_css>

    </configure>
```
### Disable all Plone standard CSS resources

It is possible to disable all Plone standard CSS resources at once. This disables all CSS resources which are registered when installing a fresh Plone without dependencies.

``` xml
    <configure
        xmlns:theme="http://namespaces.zope.org/ftw.theming"
        xmlns:zcml="http://namespaces.zope.org/zcml"
        i18n_domain="my.app">

        <include package="ftw.theming" />

        <!-- re-enable authoring.css because of important reasons -->
        <include package="plonetheme.vintage" />
        <theme:portal_css theme="plonetheme.vintage">
            <theme:disable_plone_css_resources />
        </theme:portal_css>

    </configure>
```

---

This pull request solves https://github.com/4teamwork/plonetheme.blueberry/issues/9 with a different approach than originally discussed. This approach does not change the database (`portal_css` expressions) but hooks in dynamically and is purely configured in ZCML.

// @maethu @bierik please take a look 😉 
