### PR TITLE
Fix `embed_resource` mixin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -349,11 +349,11 @@ Example:
 .. code:: scss
 
     .foo {
-        background: embed-resource("soccer.svg", $fill-css:['#pentagon': red]);
+        background: embed-resource("soccer.svg", $fill-css:('#pentagon', red));
     }
 
     .bar {
-        background: embed-resource("soccer.svg", $fill-xpath:['//*[@id="black_stuff"]/*[local-name()="g"][1]': red]);
+        background: embed-resource("soccer.svg", $fill-xpath:('//*[@id="black_stuff"]/*[local-name()="g"][1]', red));
     }
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix embed-resource mixin
 
 
 1.6.1 (2016-08-08)

--- a/ftw/theming/extensions.py
+++ b/ftw/theming/extensions.py
@@ -6,6 +6,7 @@ from scss.calculator import Calculator
 from scss.extension import Extension
 from scss.namespace import Namespace
 from scss.types import Boolean
+from scss.types import List as SCSS_list
 from scss.types import Url
 from zope.dottedname.resolve import resolve
 import inspect
@@ -53,9 +54,18 @@ def find_relative_resource(relpath):
     return path
 
 
+def chunks(l, n):
+    if not l:
+        return []
+    return [l[i:i + n] for i in xrange(0, len(l), n)]
+
+
 def fill_svg(data, fill_css=None, fill_xpath=None):
     doc = etree.fromstring(data)
     expressions = []
+
+    fill_css = chunks(fill_css, 2) if isinstance(fill_css, SCSS_list) else fill_css
+    fill_xpath = chunks(fill_xpath, 2) if isinstance(fill_css, SCSS_list) else fill_xpath
 
     for xpr, color in fill_xpath or ():
         xpath_xpr = xpr.render().strip('"').strip("'")


### PR DESCRIPTION
The current syntax for the `embed_resource` mixin is not
valid SCSS. SCSS is only able to accept a list as an argument.