### PR TITLE
Fix support for mimetype icons having long names.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix support for mimetype icons having long names. [jone, mbaechtold]
 
 
 1.7.0 (2016-09-22)

--- a/ftw/theming/browser/icons.py
+++ b/ftw/theming/browser/icons.py
@@ -1,11 +1,9 @@
+from ftw.theming import utils
 from operator import attrgetter
 from operator import methodcaller
-from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation
 from Products.Five import BrowserView
-from zope.component import getUtility
-import re
 
 
 class ThemingIcons(BrowserView):
@@ -20,13 +18,12 @@ class ThemingIcons(BrowserView):
         mimetypes_registry = getToolByName(self.context, 'mimetypes_registry')
         icon_paths = sorted(set(map(attrgetter('icon_path'),
                                     mimetypes_registry.mimetypes())))
-        normalizer = getUtility(IIDNormalizer)
 
         def itemize(filename):
-            name = normalizer.normalize(re.sub(r'\.png$', r'', filename))
+            name = utils.get_mimetype_css_class_from_icon_path(filename)
             return {
                 'filename': filename,
-                'classes': 'mimetype-icon icon-mimetype-img-{}'.format(name),
-                'normalized_name': name}
+                'classes': 'mimetype-icon {}'.format(name),
+                'normalized_name': name.replace('icon-mimetype-img-', '')}
 
         return map(itemize, icon_paths)

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -1,9 +1,6 @@
+from ftw.theming import utils
 from plone.app.layout.icons import icons
-from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize.instance import memoize
-from zope.component import getUtility
-import os.path
-import re
 
 
 WRAPPER_TEMPLATE = '<span class="{classes}">{content}</span>'
@@ -20,9 +17,6 @@ class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
                                        content=image_tag)
 
     def wrapper_classes(self):
-        normalizer = getUtility(IIDNormalizer)
-        image_filename = os.path.basename(self.url)
-        image_filename = re.sub(r'\.png$', r'', image_filename)
-        mimetype_class = 'icon-mimetype-img-{}'.format(
-            normalizer.normalize(image_filename))
-        return 'mimetype-icon {}'.format(mimetype_class)
+        return 'mimetype-icon {}'.format(
+            utils.get_mimetype_css_class_from_icon_path(self.url)
+        )

--- a/ftw/theming/utils.py
+++ b/ftw/theming/utils.py
@@ -1,4 +1,8 @@
+from plone.i18n.normalizer import IIDNormalizer
+from zope.component import getUtility
 import inspect
+import os
+import re
 
 
 def find_object_in_stack(name, klass):
@@ -6,3 +10,13 @@ def find_object_in_stack(name, klass):
     while not isinstance(frame.f_locals.get(name, None), klass):
         frame = frame.f_back
     return frame.f_locals[name]
+
+
+def get_mimetype_css_class_from_icon_path(icon_path):
+    normalizer = getUtility(IIDNormalizer)
+    image_filename = os.path.basename(icon_path)
+    image_filename = re.sub(r'\.png$', r'', image_filename)
+    image_filename = re.sub(r'\.gif$', r'', image_filename)
+    return 'icon-mimetype-img-{}'.format(
+        normalizer.normalize(image_filename, max_length=255)
+    )


### PR DESCRIPTION
The problem was that when using `++resource++...` image paths in the `resource_registry`, the normalizer did crop the last parts in order to be shorter than `50`, the default `max_length`, resulting in ambiguous CSS class names.

In this event we refactored the CSS class name generator into a separate utility function.