### PR TITLE
Support replacing portal-type- and mimetype-icons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
+- Support replacing portal-type- and mimetype-icons. [jone]
+
 - Fix support for mimetype icons having long names. [jone, mbaechtold]
 
 

--- a/ftw/theming/resources/scss/icon_mixins.scss
+++ b/ftw/theming/resources/scss/icon_mixins.scss
@@ -4,13 +4,14 @@
 $icons-portal-type-icons: ();
 
 @mixin portal-type-icon($type, $value, $iconset) {
-  $icons-portal-type-icons: append($icons-portal-type-icons,
-                                   ($type, $value, $iconset));
+  $key: "#{$iconset}:#{$type}";
+  $values: ($type, $value, $iconset);
+  $icons-portal-type-icons: map-merge($icons-portal-type-icons, ($key: $values));
 }
 
 @function get-portal-type-icons-for-iconset($requested-iconset) {
   $result: ();
-  @each $type, $value, $iconset in $icons-portal-type-icons {
+  @each $type, $value, $iconset in map-values($icons-portal-type-icons) {
     @if $iconset == $requested-iconset {
       $result: append($result, ($type, $value));
     }
@@ -40,13 +41,14 @@ $icons-mimetype-portal-types: ();
 $icons-mime-type-icons: ();
 
 @mixin mime-type-icon($classpostfix, $value, $iconset) {
-  $icons-mime-type-icons: append($icons-mime-type-icons,
-                                 ($classpostfix, $value, $iconset));
+  $key: "#{$iconset}:#{$classpostfix}";
+  $values: ($classpostfix, $value, $iconset);
+  $icons-mime-type-icons: map-merge($icons-mime-type-icons, ($key: $values));
 }
 
 @function get-mime-type-icons-for-iconset($requested-iconset) {
   $result: ();
-  @each $classpostfix, $value, $iconset in $icons-mime-type-icons {
+  @each $classpostfix, $value, $iconset in map-values($icons-mime-type-icons) {
     @if $iconset == $requested-iconset {
       $result: append($result, ($classpostfix, $value));
     }


### PR DESCRIPTION
Refactor the internal icon storage from list to map, so that existing icon definitions are replaced when an icon is redefined for an already defined portal type or mimetype.

Only the internal data structure and functions for using those are changed, thus backwards compatibility is ensured.
![screencapture-localhost-8080-plone7-theming-icons-1474902133770](https://cloud.githubusercontent.com/assets/7469/18839448/574cbb74-840b-11e6-8487-f352025d12d7.png)
