### PR TITLE
Fix caching for unpublished navigation roots

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
+- Fix caching for unpublished navigation roots by not using p.a.caching. [jone]
+
 - Introduce appearance helper
   [Kevin Bieri]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
+- Switch from "private" to "public" caching, since the CSS does
+  not contain any user specific data. [jone]
+
 - Fix caching for unpublished navigation roots by not using p.a.caching. [jone]
 
 - Introduce appearance helper

--- a/ftw/theming/browser/configure.zcml
+++ b/ftw/theming/browser/configure.zcml
@@ -22,11 +22,6 @@
         permission="zope.Public"
         />
 
-    <cache:ruleset
-        for="ftw.theming.interfaces.ICSSCaching"
-        ruleset="plone.stableResource"
-        />
-
     <browser:page
         name="theming-resources"
         for="plone.app.layout.navigation.interfaces.INavigationRoot"

--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -79,7 +79,7 @@ class ThemingCSSView(BrowserView):
             # Do not set cache headers when no cachekey provided.
             # The cached representation is to be considered fresh for 1 year
             # http://stackoverflow.com/a/3001556/880628
-            response.setHeader('Cache-Control', 'private, max-age=31536000')
+            response.setHeader('Cache-Control', 'public, max-age=31536000')
         return self.get_css()
 
     @ram.cache(ramcachekey)

--- a/ftw/theming/browser/theming_css.py
+++ b/ftw/theming/browser/theming_css.py
@@ -1,4 +1,3 @@
-from ftw.theming.interfaces import ICSSCaching
 from ftw.theming.interfaces import ISCSSCompiler
 from operator import methodcaller
 from plone.app.layout.navigation.root import getNavigationRootObject
@@ -9,7 +8,6 @@ from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import getSite
-from zope.interface import alsoProvides
 import hashlib
 
 
@@ -81,10 +79,7 @@ class ThemingCSSView(BrowserView):
             # Do not set cache headers when no cachekey provided.
             # The cached representation is to be considered fresh for 1 year
             # http://stackoverflow.com/a/3001556/880628
-            # The cache header is only active when plone.app.caching is not
-            # configured.
             response.setHeader('Cache-Control', 'private, max-age=31536000')
-            alsoProvides(self, ICSSCaching)
         return self.get_css()
 
     @ram.cache(ramcachekey)

--- a/ftw/theming/interfaces.py
+++ b/ftw/theming/interfaces.py
@@ -237,8 +237,3 @@ class ISCSSResourceFactory(Interface):
     def __call__(context, request):
         """Accepts any context and request and returns an SCSSResource object.
         """
-
-
-class ICSSCaching(Interface):
-    """Marker interface for enabling plone.app.caching on the theming resource.
-    """

--- a/ftw/theming/tests/test_theming_css_view.py
+++ b/ftw/theming/tests/test_theming_css_view.py
@@ -100,6 +100,22 @@ class TestThemingCSSView(FunctionalTestCase):
                           'Cache headers should be set.')
 
     @browsing
+    def test_caching_active_on_navroot_when_debugmode_disabled(self, browser):
+        self.portal_css.setDebugMode(False)
+        self.grant('Manager')
+        navroot = create(Builder('folder')
+                         .titled('NavRoot')
+                         .providing(INavigationRoot))
+        browser.open(navroot)
+        theming_css_url = self.get_css_url('http://nohost/plone/navroot/theming.css')
+        self.assertIn('?cachekey=', theming_css_url, 'Missing cachekey param.')
+
+        browser.open(theming_css_url)
+        self.assertEquals('private, max-age=31536000',
+                          browser.headers['Cache-Control'],
+                          'Cache headers should be set.')
+
+    @browsing
     def test_cachekey_refreshes_when_navroot_changes(self, browser):
         with freeze(datetime(2015, 1, 2, 3, 4)) as clock:
             self.portal_css.setDebugMode(False)

--- a/ftw/theming/tests/test_theming_css_view.py
+++ b/ftw/theming/tests/test_theming_css_view.py
@@ -95,7 +95,7 @@ class TestThemingCSSView(FunctionalTestCase):
         self.assertIn('?cachekey=', theming_css_url, 'Missing cachekey param.')
 
         browser.open(theming_css_url)
-        self.assertEquals('private, max-age=31536000',
+        self.assertEquals('public, max-age=31536000',
                           browser.headers['Cache-Control'],
                           'Cache headers should be set.')
 
@@ -111,7 +111,7 @@ class TestThemingCSSView(FunctionalTestCase):
         self.assertIn('?cachekey=', theming_css_url, 'Missing cachekey param.')
 
         browser.open(theming_css_url)
-        self.assertEquals('private, max-age=31536000',
+        self.assertEquals('public, max-age=31536000',
                           browser.headers['Cache-Control'],
                           'Cache headers should be set.')
 


### PR DESCRIPTION
    plone.app.caching does not ever cache resources which are not public (View
    for Anonymous).
    This means that when using plone.app.caching we cannot cache the
    generated CSS within unpublished navigation roots at all.
    Since the CSS does not really contain any information about the
    navigation root it is not a problem to cache it, and we should cache it
    whenever possible since building the CSS is considered slow.
    
    Therefore we no longer use plone.app.caching in order to set the
    Cache-Control response headers. We now always do this manually.

-
    theming.css: cache with public, not private.
    
    Since the CSS does not contain any user specific data, it can safely be
    cached in a public caching proxy.

