### PR TITLE
Introduce new helper mixins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -387,6 +387,35 @@ Example usage:
         }
     }
 
+Including font faces
+--------------------
+
+.. code:: scss
+
+  @include font-face($name: 'VerdanaRegular', $path: '++resource++nidau.web/fonts/Verdana');
+
+The file-extension for the ``$path`` argument is going to be concatenated automatically.
+Both ``woff`` and ``woff2`` must be provided.
+
+The mixin then produces the following css code:
+
+.. code:: css
+
+  @font-face {
+    font-family: 'VerdanaRegular';
+    font-style: normal;
+    font-weight: normal;
+    src: url("++resource++nidau.web/fonts/Verdana.woff2") format(woff2),
+      url("++resource++nidau.web/fonts/Verdana.woff") format(woff);
+  }
+
+  @font-face {
+    font-family: 'VerdanaBold';
+    font-style: normal;
+    font-weight: bold;
+    src: url("++resource++nidau.web/fonts/Verdana-Bold.woff2") format(woff2),
+      url("++resource++nidau.web/fonts/Verdana-Bold.woff") format(woff);
+  }
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,13 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce new mixins
+
+  - Introduce link-color helper
+  - Introduce font-face helper
+  - Introduce rem helper
+
+  [Kevin Bieri]
 
 
 1.8.0 (2016-10-06)

--- a/ftw/theming/resources.zcml
+++ b/ftw/theming/resources.zcml
@@ -17,6 +17,7 @@
     <theme:scss file="resources/scss/globals/zindex.scss" slot="variables" />
     <theme:scss file="resources/scss/globals/helpers.scss" slot="mixins" />
     <theme:scss file="resources/scss/globals/grid.scss" slot="mixins" />
+    <theme:scss file="resources/scss/globals/fontface.scss" slot="mixins" />
 
     <theme:scss file="resources/scss/elements/button.scss" slot="mixins" />
     <theme:scss file="resources/scss/elements/list.scss" slot="mixins" />

--- a/ftw/theming/resources/scss/globals/fontface.scss
+++ b/ftw/theming/resources/scss/globals/fontface.scss
@@ -1,0 +1,12 @@
+@mixin font-face($name, $path, $weight: normal, $style: normal, $formats: woff2 woff) {
+  $src: null;
+  @each $format in $formats {
+    $src: append($src, url($path + '.' + $format) format($format), comma);
+  }
+  @font-face {
+    font-family: $name;
+    font-style: $style;
+    font-weight: $weight;
+    src: $src;
+  }
+}

--- a/ftw/theming/resources/scss/globals/helpers.scss
+++ b/ftw/theming/resources/scss/globals/helpers.scss
@@ -109,6 +109,10 @@
   @return $pixels / $context * 1em;
 }
 
+@function rem($pixels: 0, $context: $font-size-base) {
+  @return $pixels / $context * 1rem;
+}
+
 @mixin transform($transforms...) {
   -webkit-transform: #{$transforms};
           transform: #{$transforms};

--- a/ftw/theming/resources/scss/globals/helpers.scss
+++ b/ftw/theming/resources/scss/globals/helpers.scss
@@ -66,10 +66,27 @@
   &:hover {
     @include auto-text-color($color);
   }
+
   &:visited {
     @include auto-text-color($color);
     &:hover {
       @include auto-text-color($color);
+    }
+  }
+}
+
+@mixin link-color($color-link: $color-link, $color-link-hover: $color-link-hover) {
+  color: $color-link;
+
+  &:hover {
+    color: $color-link-hover;
+  }
+
+  &:visited {
+    color: $color-link;
+
+    &:hover {
+      color: $color-link-hover;
     }
   }
 }

--- a/ftw/theming/resources/scss/iconset_font-awesome.scss
+++ b/ftw/theming/resources/scss/iconset_font-awesome.scss
@@ -10,6 +10,7 @@
       font-family: FontAwesome;
       text-align: center;
       min-width: $line-height-base;
+      font-weight: normal;
     }
   }
   .#{$fa-css-prefix}-icon-right {


### PR DESCRIPTION
Helpers:

- `rem`: This helper converts pixel to `rem` units.

- font-face helper: This helpers generates font face definition to support different browsers
``` scss
@include font-face($name: 'VerdanaRegular', $path: '++resource++nidau.web/fonts/Verdana');
@include font-face($name: 'VerdanaBold', $path: '++resource++nidau.web/fonts/Verdana-Bold', $weight: bold);
```

The file-extension for the `$path` argument is going to be concatenated automatically. Both `woff` and `woff2` must be provided.

produces:
``` css
@font-face {
  font-family: 'VerdanaRegular';
  font-style: normal;
  font-weight: normal;
  src: url("++resource++nidau.web/fonts/Verdana.woff2") format(woff2),
    url("++resource++nidau.web/fonts/Verdana.woff") format(woff);
}

@font-face {
  font-family: 'VerdanaBold';
  font-style: normal;
  font-weight: bold;
  src: url("++resource++nidau.web/fonts/Verdana-Bold.woff2") format(woff2),
    url("++resource++nidau.web/fonts/Verdana-Bold.woff") format(woff);
}
```

- link-color helper: This helpers generates styles for a link in both hover and active state