### PR TITLE
Use two columns for print layout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Use two columns for print layout.
+  [Kevin Bieri]
+
 - Avoid duplicate (mimetype) icons on "Image" types. [jone]
 
 - Introduce new mixins

--- a/ftw/theming/resources/scss/globals/grid.scss
+++ b/ftw/theming/resources/scss/globals/grid.scss
@@ -48,8 +48,17 @@ $gridsystem-width: $columns * $column-width + ($columns - 1) * $gutter-width + 2
   }
 
   @media print {
-    width: 100% !important;
-    margin-right: 0 !important;
+    width: ((100% / $row-width) * $row-split-width-factor) + (($gutter-width-relative / $row-width) * $row-split-width-factor) - $gutter-width-relative;
+    margin-right: $gutter-width-relative;
+    @if $by-index {
+      &:nth-child(#{$row-split-width + $offset}n+#{$row-split-width + $offset}) {
+        margin-right: 0;
+      }
+    } @else {
+      &:nth-of-type(#{$row-split-width + $offset}n+#{$row-split-width + $offset}) {
+        margin-right: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
There is enough space an a DINA4 to display two columns next to each other.
With the previous layout, the gallery is printed too large.

Closes https://github.com/4teamwork/ai.web/issues/155

![screen shot 2016-12-28 at 10 54 56](https://cloud.githubusercontent.com/assets/1637820/21519317/73fd47be-ccec-11e6-8ad3-7c6ee7ef12f7.png)
