### PR TITLE
Avoid duplicate (mimetype) icons on "Image" types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Avoid duplicate (mimetype) icons on "Image" types. [jone]
+
 - Introduce new mixins
 
   - Introduce link-color helper

--- a/ftw/theming/resources/scss/base/standard_icons.scss
+++ b/ftw/theming/resources/scss/base/standard_icons.scss
@@ -42,6 +42,7 @@
 
 /* MIMETYPES */
 @include mark-portal-type-having-mimetypes(file);
+@include mark-portal-type-having-mimetypes(image);
 
 /* Default */
 @include mime-type-font-awesome-icon(mime, file-o);


### PR DESCRIPTION
By marking the "Image" type to have mimetype icons we awoid duplicate icons (portal_type icon + mimetype icon).

**Before:**
![bildschirmfoto 2017-01-06 um 11 59 12](https://cloud.githubusercontent.com/assets/7469/21715971/d440857e-d407-11e6-86d0-9366875eb80f.png)

**After:**
![bildschirmfoto 2017-01-06 um 11 59 22](https://cloud.githubusercontent.com/assets/7469/21715973/d5dbb28c-d407-11e6-9c33-1733f23d44aa.png)
