### PR TITLE
Add support for installation with quickinstaller

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,9 @@ Changelog
 
 - Add uninstall profile [raphael-s]
 
+- Make sure the default profile is installed when installing ftw.theming with
+  quickinstaller. [raphael-s]
+
 
 1.9.0 (2017-02-09)
 ------------------

--- a/ftw/theming/Extensions/install.py
+++ b/ftw/theming/Extensions/install.py
@@ -1,6 +1,11 @@
 from Products.CMFCore.utils import getToolByName
 
 
+def install(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile('profile-ftw.theming:default')
+
+
 def uninstall(self):
     setup_tool = getToolByName(self, 'portal_setup')
     setup_tool.runAllImportStepsFromProfile(


### PR DESCRIPTION
When installing `ftw.theming` with the quickinstaller the default profile now gets installed along with the base profile.

This makes `ftw.theming` compatible with quickinstaller and allows for reinstallations.

closes #72 