### PR TITLE
Fix escaping of fontface mixin.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix escaping of font type on fontface mixin. [Kevin Bieri]
 - Provide background option for tab-list mixin. [Kevin Bieri]
 - Introduce hyphenation mixin. [Bieri Kevin]
 

--- a/ftw/theming/resources/scss/globals/fontface.scss
+++ b/ftw/theming/resources/scss/globals/fontface.scss
@@ -1,12 +1,13 @@
 @mixin font-face($name, $path, $weight: normal, $style: normal, $formats: woff2 woff) {
   $src: null;
   @each $format in $formats {
-    $src: append($src, url($path + '.' + $format) format($format), comma);
+    $src: append($src, url($path + '.' + $format) format('#{$format}'), comma);
   }
   @font-face {
     font-family: $name;
     font-style: $style;
     font-weight: $weight;
     src: $src;
+    @content;
   }
 }


### PR DESCRIPTION
Before:
``` scss
@font-face {
  ...
  src: url("http://...") format(woff2),
  ...
}
```

After:
``` scss
@font-face {
  ...
  src: url("http://...") format('woff2'),
  ...
}
```

Notice the quotes around the format declaration.

Additionally add option to pass a unicode range as the mixin-content.

See example from GoogleFontsAPI -> https://fonts.googleapis.com/css?family=Open+Sans:400,700&amp;subset=latin-ext