### PR TITLE
Change values of default colors to make new sites more appealing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Change default colors so new pages will look better out of the box.
+  ! This may change the appearance of existing sites ! [raphael-s]
 
 
 1.10.1 (2017-06-02)

--- a/ftw/theming/resources/scss/globals/variables.scss
+++ b/ftw/theming/resources/scss/globals/variables.scss
@@ -2,9 +2,9 @@
   Colors
  */
 
-$color-primary: #3B234A !default;
-$color-secondary: #BAAFC4 !default;
-$color-edit: #75ad0a !default;
+$color-primary: #2980b9 !default;
+$color-secondary: #c0def1 !default;
+$color-edit: #2abb67 !default;
 
 $color-default: #2980b9 !default;
 $color-success: #21ba45 !default;
@@ -12,11 +12,11 @@ $color-warning: #eab055 !default;
 $color-danger: #db2828 !default;
 
 $color-white: #fff !default;
-$color-gray-dark: #e6e6e6 !default;
-$color-gray-light: #f5f5f5 !default;
+$color-gray-dark: #bdc3C7 !default;
+$color-gray-light: #f1f3f3 !default;
 
-$color-text: #444 !default;
-$color-text-inverted: #efefef !default;
+$color-text: #2c3e50 !default;
+$color-text-inverted: #ecf0f1 !default;
 $color-text-light: #95a5a6 !default;
 
 $color-link: $color-primary !default;

--- a/ftw/theming/tests/test_controlpanel.py
+++ b/ftw/theming/tests/test_controlpanel.py
@@ -57,7 +57,7 @@ class TestControlpanel(FunctionalTestCase):
 
         self.assertIn({'File': 'variables.scss',
                        'Name': '$color-primary',
-                       'Value': '#3B234A',
+                       'Value': '#2980b9',
                        'Example': ''},
                       variables)
 


### PR DESCRIPTION
IMO the old default colors didn't look that great. I changed some of the colors asserted to the variables by default to make new sites look more appealing out of the box.

I think new Plone sites look way better now without having to change the colors.

Old look:
<img width="1440" alt="screen shot 2017-06-30 at 14 09 49" src="https://user-images.githubusercontent.com/16755391/27735026-ce5c43c6-5d9d-11e7-9b31-cabc9554debb.png">

New look:
<img width="1440" alt="screen shot 2017-06-30 at 14 09 33" src="https://user-images.githubusercontent.com/16755391/27735031-d2eeb586-5d9d-11e7-84b0-c33436cd0990.png">

❗️ Those changes may change the look of some sites with custom styling. But the problems caused by this should be fixable with small effort. ❗️ 