### PR TITLE
Remove deprecated variables.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -366,11 +366,9 @@ Using media queries Mixins
 
 ``ftw.theming`` provides mixins for most common media queries:
 
-- phone (800px)
-- tablet (1024px)
-- desktop-M (1360px) - HD
-- desktop-L (1920px) - Full HD
-- desktop-XL (2560px) - WQHD
+- small (480px)
+- medium (800px)
+- large (1024)
 
 Example usage:
 
@@ -379,10 +377,10 @@ Example usage:
     #container {
         width: 1600px;
 
-        @include tablet {
+        @include screen-medium {
             width:1000px;
         }
-        @include phone {
+        @include screen-small {
             width:500px;
         }
     }

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.11.1 (unreleased)
+2.0.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Deprecate legacy breakpoint mixins and variables. [Kevin Bieri]
+- Remove deprecated variables. [Kevin Bieri]
 
 
 1.11.0 (2017-12-19)

--- a/ftw/theming/resources/scss/globals/variables.scss
+++ b/ftw/theming/resources/scss/globals/variables.scss
@@ -137,61 +137,35 @@ $spinner-url: "" !default;
   line-height-base,
   spinner-url);
 
-/* Viewports */
-
-// Taken from http://en.wikipedia.org/wiki/Display_resolution
-$desktop-WQHD-width:   2560px !default;
-$desktop-FHD-width:    1920px !default;
-$desktop-HDPLUS-width: 1600px !default;
-$desktop-HD-width:     1360px !default;
-$desktop-WXGA-width:   1280px !default;
-$desktop-XGA-width:    1024px !default;
-
-// Taken from http://www.ciop.com/common-resolutions-for-mobile-phones-and-tablets
-$mobile-large: 1280px !default;
-$mobile-medium: 1024px !default;
-$mobile-small: 800px !default;
-$mobile-smaller: 600px !default;
-$mobile-tiny: 480px !default;
-
-$screen-XL: "(min-width: #{$desktop-WQHD-width})" !default;
-$screen-L: "(min-width: #{$desktop-HDPLUS-width})" !default;
-$screen-M: "(min-width: #{$desktop-HD-width})" !default;
-$screen-S: "(min-width: #{$desktop-XGA-width})" !default;
-$screen-XS: "(min-width: #{$mobile-small})" !default;
-$screen-XXS: "(min-width: #{$mobile-tiny})" !default;
-
-@include declare-variables(
-  screen-XL,
-  screen-L,
-  screen-M,
-  screen-S,
-  screen-XS);
-
 @mixin desktop-XL {
+  @warn 'This old mixin is deprecated';
   @media #{$screen-XL} {
     @content;
   }
 }
 
 @mixin desktop-L {
+  @warn 'This old mixin is deprecated';
   @media #{$screen-L} {
     @content;
   }
 }
 
 @mixin desktop-M {
+  @warn 'This old mixin is deprecated';
   @media #{$screen-M} {
     @content;
   }
 }
 
 @mixin tablet {
+  @warn 'This old mixin is deprecated';
   @media #{$screen-S} {
     @content;
   }
 }
 @mixin phone {
+  @warn 'This old mixin is deprecated';
   @media #{$screen-XS} {
     @content;
   }
@@ -219,6 +193,11 @@ $screen-XXS: "(min-width: #{$mobile-tiny})" !default;
   }
 }
 
+@include declare-variables(
+  screen-S,
+  screen-XS,
+  screen-XXS);
+
 /* ICONS */
 
 $standard-iconset: font-awesome !default;
@@ -226,3 +205,27 @@ $use-font-awesome-mimetype-icons: true !default;
 @include declare-variables(
   standard-iconset,
   use-font-awesome-mimetype-icons);
+
+/* These variable are deprecated */
+
+// Taken from http://en.wikipedia.org/wiki/Display_resolution
+$desktop-WQHD-width:   2560px !default;
+$desktop-FHD-width:    1920px !default;
+$desktop-HDPLUS-width: 1600px !default;
+$desktop-HD-width:     1360px !default;
+$desktop-WXGA-width:   1280px !default;
+$desktop-XGA-width:    1024px !default;
+
+// Taken from http://www.ciop.com/common-resolutions-for-mobile-phones-and-tablets
+$mobile-large: 1280px !default;
+$mobile-medium: 1024px !default;
+$mobile-small: 800px !default;
+$mobile-smaller: 600px !default;
+$mobile-tiny: 480px !default;
+
+$screen-XL: "(min-width: #{$desktop-WQHD-width})" !default;
+$screen-L: "(min-width: #{$desktop-HDPLUS-width})" !default;
+$screen-M: "(min-width: #{$desktop-HD-width})" !default;
+$screen-S: "(min-width: #{$desktop-XGA-width})" !default;
+$screen-XS: "(min-width: #{$mobile-small})" !default;
+$screen-XXS: "(min-width: #{$mobile-tiny})" !default;

--- a/ftw/theming/resources/scss/globals/variables.scss
+++ b/ftw/theming/resources/scss/globals/variables.scss
@@ -218,56 +218,6 @@ $screen-XXS: "(min-width: #{$mobile-tiny})" !default;
     @content;
   }
 }
-/*
-  Deprecated Variables
-  Will be removed in next major version.
- */
-
-
-$primary-color: #205C90 !default;
-$secondary-color: #75ad0a !default;
-
-$gray-base: #403e3d !default;
-$gray-darker: lighten($gray-base, 13.5%) !default;
-$gray-dark: lighten($gray-base, 20%) !default;
-$gray: lighten($gray-base, 33.5%) !default;
-$gray-light: lighten($gray-base, 46.7%) !default;
-$gray-lighter: lighten($gray-base, 70%) !default;
-
-$standalone-color: #fafafa !default;
-$context-color: #337ab7 !default;
-$success-color: #5cb85c !default;
-$warning-color: #f0ad4e !default;
-$danger-color: #d9534f !default;
-
-$page-bg-color: $gray-lighter !default;
-$content-bg-color: #fff !default;
-$text-color: $gray-dark !default;
-$light-text-color: $gray-light !default;
-$link-color: $primary-color !default;
-$link-font-weight: normal !default;
-$link-hover-color: $secondary-color !default;
-$link-focus-color: $secondary-color !default;
-$link-decoration: none !default;
-$link-hover-decoration: underline !default;
-$outline-color: change-color($primary-color, $lightness: 60%) !default;
-
-$button-standalone-color: $standalone-color !default;
-$button-context-color: $context-color !default;
-$button-destructive-color: $danger-color !default;
-$button-success-color: $success-color !default;
-$button-warning-color: $warning-color !default;
-$button-danger-color: $danger-color !default;
-
-$button-standalone-color: $color-secondary !default;
-$button-context-color: $color-default !default;
-$button-destructive-color: $color-danger !default;
-$button-success-color: $color-success !default;
-$button-warning-color: $color-warning !default;
-$button-danger-color: $color-danger !default;
-$button-disabled-color: #ddd !default;
-$button-text-light-color: white !default;
-$button-text-dark-color: black !default;
 
 /* ICONS */
 


### PR DESCRIPTION
- Remove deprecated variables.


- Define new deprecated viewport mixins and variables.
The only mixin available will be:

``` scss
@mixin screen-large
@mixin screen-medium
@mixin screen-small
```

I updated both `ftw.subsite` and `ftw.mobile` to be compatible with the newest version.
https://github.com/4teamwork/ftw.subsite/pull/103 https://github.com/4teamwork/ftw.mobile/pull/53
