### PR TITLE
Fix UnicodeEncodeError error for content types with unicode characters

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix UnicodeEncodeError error for content types names with unicode characters [Nachtalb]
 
 
 2.0.0 (2018-01-17)

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -3,7 +3,7 @@ from plone.app.layout.icons import icons
 from plone.memoize.instance import memoize
 
 
-WRAPPER_TEMPLATE = '<span class="{classes}">{content}</span>'
+WRAPPER_TEMPLATE = u'<span class="{classes}">{content}</span>'
 
 
 class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):


### PR DESCRIPTION
This eg. occurred for the french translations of content types in PloneFormGen.