### PR TITLE
plone.browserlayer subscriber must be registered before our subscriber

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- plone.browserlayer subscriber must be registered before our subscriber [Nachtalb]
 
 
 2.0.1 (2019-01-17)

--- a/ftw/theming/configure.zcml
+++ b/ftw/theming/configure.zcml
@@ -62,6 +62,9 @@
         directory="upgrades/base"
         />
 
+    <!-- The set_ftw_theming_header subscriber relies on the browserlayer to be applied to the request, in order to
+         guarantee that, the plone.browserlayer subscriber must be registered first.-->
+    <include package="plone.browserlayer" />
     <subscriber
         for="Products.CMFCore.interfaces.ISiteRoot
              zope.traversing.interfaces.IBeforeTraverseEvent"


### PR DESCRIPTION
The set_ftw_theming_header subscriber relies on the browserlayer to be applied to the request, in order to guarantee that, the plone.browserlayer subscriber must be registered first.