### PR TITLE
Improve mimetype icons support for better Plone 5 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve mimetype icons support for better Plone 5 support. [jone]
 
 
 2.0.2 (2019-03-19)

--- a/ftw/theming/browser/icons.py
+++ b/ftw/theming/browser/icons.py
@@ -1,5 +1,4 @@
 from ftw.theming import utils
-from operator import attrgetter
 from operator import methodcaller
 from Products.CMFCore.utils import getToolByName
 from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation
@@ -16,14 +15,24 @@ class ThemingIcons(BrowserView):
 
     def get_mime_types(self):
         mimetypes_registry = getToolByName(self.context, 'mimetypes_registry')
-        icon_paths = sorted(set(map(attrgetter('icon_path'),
-                                    mimetypes_registry.mimetypes())))
+        result = []
+        seen_path = set()
 
-        def itemize(filename):
-            name = utils.get_mimetype_css_class_from_icon_path(filename)
-            return {
-                'filename': filename,
-                'classes': 'mimetype-icon {}'.format(name),
-                'normalized_name': name.replace('icon-mimetype-img-', '')}
+        for mimetype in mimetypes_registry.mimetypes():
+            if not mimetype.icon_path or not mimetype.mimetypes:
+                continue
+            if mimetype.icon_path in seen_path:
+                continue
+            seen_path.add(mimetype.icon_path)
 
-        return map(itemize, icon_paths)
+            img_class = utils.get_mimetype_css_class_from_icon_path(mimetype.icon_path)
+            mime_type_class = utils.get_mimetype_css_class_from_mime_type(
+                mimetype.mimetypes[0])
+            result.append({
+                'filename': mimetype.icon_path,
+                'getIcon_based_classes': 'mimetype-icon {}'.format(img_class),
+                'normalized_name': img_class.replace('icon-mimetype-img-', ''),
+                'mime_type_based_classes': 'mimetype-icon {}'.format(mime_type_class),
+                'normalized_mime_type': mime_type_class.replace('icon-mimetype-mt-', '')})
+
+        return result

--- a/ftw/theming/browser/templates/icons.pt
+++ b/ftw/theming/browser/templates/icons.pt
@@ -85,12 +85,16 @@
             <colgroup>
                 <col width="10%" />
                 <col width="10%" />
-                <col width="80%" />
+                <col width="10%" />
+                <col width="30%" />
+                <col width="40%" />
             </colgroup>
             <thead>
                 <tr>
                     <th i18n:translate="">Original</th>
-                    <th i18n:translate="">Icon</th>
+                    <th i18n:translate="">getIcon based</th>
+                    <th i18n:translate="">mime_type based</th>
+                    <th i18n:translate="">normalized mime_type</th>
                     <th i18n:translate="">Name</th>
                 </tr>
             </thead>
@@ -102,8 +106,12 @@
                             <img tal:attributes="src string:${here/portal_url}/${item/filename}" />
                         </td>
                         <td>
-                            <span tal:attributes="class item/classes" />
+                            <span tal:attributes="class item/getIcon_based_classes" />
                         </td>
+                        <td>
+                            <span tal:attributes="class item/mime_type_based_classes" />
+                        </td>
+                        <td tal:content="item/normalized_mime_type" />
                         <td tal:content="item/normalized_name" />
                     </tr>
                 </tal:MIMETYPE>

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -3,7 +3,7 @@ from plone.app.layout.icons import icons
 from plone.memoize.instance import memoize
 
 
-WRAPPER_TEMPLATE = u'<span class="{classes}">{content}</span>'
+WRAPPER_TEMPLATE = u'<span class="mimetype-icon {cssclass}">{content}</span>'
 
 
 class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
@@ -11,12 +11,11 @@ class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
     @memoize
     def html_tag(self):
         image_tag = super(CatalogBrainContentIcon, self).html_tag()
-        if image_tag is None:
-            return None
-        return WRAPPER_TEMPLATE.format(classes=self.wrapper_classes(),
-                                       content=image_tag)
-
-    def wrapper_classes(self):
-        return 'mimetype-icon {}'.format(
-            utils.get_mimetype_css_class_from_icon_path(self.url)
-        )
+        if image_tag is not None:
+            return WRAPPER_TEMPLATE.format(
+                cssclass=utils.get_mimetype_css_class_from_icon_path(self.url),
+                content=image_tag)
+        else:
+            return WRAPPER_TEMPLATE.format(
+                cssclass=utils.get_mimetype_css_class_from_mime_type(self.brain.mime_type),
+                content='')

--- a/ftw/theming/resources/scss/base/standard_icons.scss
+++ b/ftw/theming/resources/scss/base/standard_icons.scss
@@ -45,9 +45,12 @@
 @include mark-portal-type-having-mimetypes(image);
 
 /* Default */
-@include mime-type-font-awesome-icon(mime, file-o);
+@include mime-type-font-awesome-icon(mime, envelope-o);
 @include mime-type-font-awesome-icon(application, file-o);
 @include mime-type-font-awesome-icon(unknown, file-o);
+@include mime-type-font-awesome-icon-mt(message-rfc822, envelope-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-hp-pcl, file-o);
+@include mime-type-font-awesome-icon-mt(inode-symlink, file-o);
 
 /* ms office */
 @include mime-type-font-awesome-icon(doc, file-word-o);
@@ -56,6 +59,13 @@
 @include mime-type-font-awesome-icon(xlsx, file-excel-o);
 @include mime-type-font-awesome-icon(ppt, file-powerpoint-o);
 @include mime-type-font-awesome-icon(pptx, file-powerpoint-o);
+@include mime-type-font-awesome-icon-mt(application-msword, file-word-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-openxmlformats-officedocument-wordprocessingml-document, file-word-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-ms-excel, file-excel-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-openxmlformats-officedocument-spreadsheetml-sheet, file-excel-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-ms-powerpoint, file-powerpoint-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-openxmlformats-officedocument-presentationml-presentation, file-powerpoint-o);
+
 
 /* open office */
 @include mime-type-font-awesome-icon(sxc, file-excel-o);
@@ -76,12 +86,34 @@
 @include mime-type-font-awesome-icon(resource-mtr-icons-otp, file-powerpoint-o);
 @include mime-type-font-awesome-icon(resource-mtr-icons-ots, file-excel-o);
 @include mime-type-font-awesome-icon(resource-mtr-icons-ott, file-word-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-calc, file-excel-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-draw, file-image-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-impress, file-powerpoint-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-openxmlformats-officedocument-presentationml-slide, file-powerpoint-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-math, file-excel-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-writer-global, file-word-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-sun-xml-writer, file-word-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-ms-word-template-macroEnabled-12, file-word-o);
 
 
 /* images */
 @include mime-type-font-awesome-icon(image, file-image-o);
 @include mime-type-font-awesome-icon(ps, file-image-o);
 @include mime-type-font-awesome-icon(png, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-x-coreldraw, file-image-o);
+@include mime-type-font-awesome-icon-mt(application-postscript, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-bmp, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-gif, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-ief, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-jp2, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-jpeg, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-png, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-psd, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-svg, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-svg-xml, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-tiff, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-vnd-adobe-photoshop, file-image-o);
+@include mime-type-font-awesome-icon-mt(image-xiff, file-image-o);
 
 /* archives */
 @include mime-type-font-awesome-icon(rar, file-archive-o);
@@ -91,6 +123,14 @@
 @include mime-type-font-awesome-icon(deb, file-archive-o);
 @include mime-type-font-awesome-icon(iso, file-archive-o);
 @include mime-type-font-awesome-icon(pk, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-rar, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-x-rpm, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-x-tar, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-zip, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-vnd-debian-binary-package, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-x-cd-image, file-archive-o);
+@include mime-type-font-awesome-icon-mt(application-x-tex-pk, file-archive-o);
+
 
 /* media */
 @include mime-type-font-awesome-icon(audio, file-audio-o);
@@ -98,6 +138,11 @@
 @include mime-type-font-awesome-icon(wav, file-audio-o);
 @include mime-type-font-awesome-icon(video, file-video-o);
 @include mime-type-font-awesome-icon(avi, file-video-o);
+@include mime-type-font-awesome-icon-mt(audio-vnd-lucent-voice, file-audio-o);
+@include mime-type-font-awesome-icon-mt(audio-midi, file-audio-o);
+@include mime-type-font-awesome-icon-mt(audio-x-wav, file-audio-o);
+@include mime-type-font-awesome-icon-mt(video-vnd-dvb-file, file-video-o);
+@include mime-type-font-awesome-icon-mt(video-x-msvideo, file-video-o);
 
 /* generic / various */
 @include mime-type-font-awesome-icon(dvi, file-o);
@@ -109,6 +154,16 @@
 @include mime-type-font-awesome-icon(font, font);
 @include mime-type-font-awesome-icon(gf, font);
 @include mime-type-font-awesome-icon(vcard, user);
+@include mime-type-font-awesome-icon-mt(application-x-dvi, file-o);
+@include mime-type-font-awesome-icon-mt(application-pdf, file-pdf-o);
+@include mime-type-font-awesome-icon-mt(text-plain, file-text-o);
+@include mime-type-font-awesome-icon-mt(text-x-web-intelligent, file-text-o);
+@include mime-type-font-awesome-icon-mt(application-x-troff-man, file-text-o);
+@include mime-type-font-awesome-icon-mt(message-x-gnu-rmail, envelope-o);
+@include mime-type-font-awesome-icon-mt(font-truetype, font);
+@include mime-type-font-awesome-icon-mt(application-x-tex-gf, font);
+@include mime-type-font-awesome-icon-mt(text-vcard, user);
+
 
 /* code */
 @include mime-type-font-awesome-icon(sh, file-code-o);
@@ -123,3 +178,15 @@
 @include mime-type-font-awesome-icon(html, file-code-o);
 @include mime-type-font-awesome-icon(pl, file-code-o);
 @include mime-type-font-awesome-icon(tex, file-code-o);
+@include mime-type-font-awesome-icon-mt(application-x-shellscript, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-java, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-csrc, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-chdr, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-python, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-c--src, file-code-o);
+@include mime-type-font-awesome-icon-mt(application-x-msdos-program, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-fortran, file-code-o);
+@include mime-type-font-awesome-icon-mt(application-x-object, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-html, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-perl, file-code-o);
+@include mime-type-font-awesome-icon-mt(text-x-tex, file-code-o);

--- a/ftw/theming/resources/scss/icon_mixins.scss
+++ b/ftw/theming/resources/scss/icon_mixins.scss
@@ -38,17 +38,17 @@ $icons-mimetype-portal-types: ();
 
 /* Mime type icons registry */
 
-$icons-mime-type-icons: ();
+$icons-mime-img-type-icons: ();
 
 @mixin mime-type-icon($classpostfix, $value, $iconset) {
   $key: "#{$iconset}:#{$classpostfix}";
   $values: ($classpostfix, $value, $iconset);
-  $icons-mime-type-icons: map-merge($icons-mime-type-icons, ($key: $values));
+  $icons-mime-img-type-icons: map-merge($icons-mime-img-type-icons, ($key: $values));
 }
 
 @function get-mime-type-icons-for-iconset($requested-iconset) {
   $result: ();
-  @each $classpostfix, $value, $iconset in map-values($icons-mime-type-icons) {
+  @each $classpostfix, $value, $iconset in map-values($icons-mime-img-type-icons) {
     @if $iconset == $requested-iconset {
       $result: append($result, ($classpostfix, $value));
     }
@@ -58,4 +58,52 @@ $icons-mime-type-icons: ();
 
 @mixin mime-type-font-awesome-icon($classpostfix, $value) {
   @include mime-type-icon($classpostfix, $value, font-awesome);
+}
+
+/* Mime type icons registry; getIcon based */
+
+$icons-mime-img-type-icons: ();
+
+@mixin mime-type-icon($classpostfix, $value, $iconset) {
+  $key: "#{$iconset}:#{$classpostfix}";
+  $values: ($classpostfix, $value, $iconset);
+  $icons-mime-img-type-icons: map-merge($icons-mime-img-type-icons, ($key: $values));
+}
+
+@function get-mime-type-icons-for-iconset($requested-iconset) {
+  $result: ();
+  @each $classpostfix, $value, $iconset in map-values($icons-mime-img-type-icons) {
+    @if $iconset == $requested-iconset {
+      $result: append($result, ($classpostfix, $value));
+    }
+  }
+  @return $result;
+}
+
+@mixin mime-type-font-awesome-icon($classpostfix, $value) {
+  @include mime-type-icon($classpostfix, $value, font-awesome);
+}
+
+/* Mime type icons registry mime_type based */
+
+$icons-mime-mt-type-icons: ();
+
+@mixin mime-type-icon-mt($classpostfix, $value, $iconset) {
+  $key: "#{$iconset}:#{$classpostfix}";
+  $values: ($classpostfix, $value, $iconset);
+  $icons-mime-mt-type-icons: map-merge($icons-mime-mt-type-icons, ($key: $values));
+}
+
+@function get-mime-type-mt-icons-for-iconset($requested-iconset) {
+  $result: ();
+  @each $classpostfix, $value, $iconset in map-values($icons-mime-mt-type-icons) {
+    @if $iconset == $requested-iconset {
+      $result: append($result, ($classpostfix, $value));
+    }
+  }
+  @return $result;
+}
+
+@mixin mime-type-font-awesome-icon-mt($classpostfix, $value) {
+  @include mime-type-icon-mt($classpostfix, $value, font-awesome);
 }

--- a/ftw/theming/resources/scss/iconset_font-awesome.scss
+++ b/ftw/theming/resources/scss/iconset_font-awesome.scss
@@ -78,5 +78,19 @@
       }
     }
 
+    body.icons-on span.mimetype-icon {
+      &[class^="icon-mimetype-mt-"], &[class*=" icon-mimetype-mt-"] {
+        @extend .fa-icon;
+        @extend .#{$fa-css-prefix}-file-o;
+      }
+    }
+
+    @each $classpostfix, $value in get-mime-type-mt-icons-for-iconset(font-awesome) {
+      body.icons-on span.mimetype-icon.icon-mimetype-mt-$classpostfix {
+        @extend .fa-icon;
+        @extend .#{$fa-css-prefix}-#{$value};
+      }
+    }
+
   }
 }

--- a/ftw/theming/tests/__init__.py
+++ b/ftw/theming/tests/__init__.py
@@ -2,7 +2,7 @@ from ftw.theming.interfaces import ISCSSRegistry
 from ftw.theming.testing import THEMING_FUNCTIONAL
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 import transaction
 

--- a/ftw/theming/tests/test_controlpanel.py
+++ b/ftw/theming/tests/test_controlpanel.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.theming.tests import FunctionalTestCase
+from ftw.theming.utils import IS_PLONE_5
 from plone.app.testing import SITE_OWNER_NAME
 
 
@@ -78,4 +79,23 @@ class TestControlpanel(FunctionalTestCase):
     def test_theming_icons_lists_mime_type_icons(self, browser):
         browser.login(SITE_OWNER_NAME).open(view='theming-icons')
         icons = browser.css('table.theming-mime-type-icons').first.dicts()
-        self.assertIn({'Name': 'pdf', 'Original': '', 'Icon': ''}, icons)
+        self.assertIn({
+            'Original': '',
+            'getIcon based': '',
+            'mime_type based': '',
+            'Name': 'pdf',
+            'normalized mime_type': 'application-pdf'}, icons)
+
+        row = browser.css('table.theming-mime-type-icons').first.find('pdf').parent('tr')
+        if IS_PLONE_5:
+            icon_image_html = u'<img src="http://nohost/plone/++resource++mimetype.icons/pdf.png">'
+        else:
+            icon_image_html = u'<img src="http://nohost/plone/pdf.png">'
+
+        self.assertEqual(
+            [icon_image_html,
+             u'<span class="mimetype-icon icon-mimetype-img-pdf"></span>',
+             u'<span class="mimetype-icon icon-mimetype-mt-application-pdf"></span>',
+             u'application-pdf',
+             u'pdf'],
+            [cell.innerHTML.strip() for cell in row.cells])

--- a/ftw/theming/tests/test_file_resource.py
+++ b/ftw/theming/tests/test_file_resource.py
@@ -6,7 +6,7 @@ from ftw.theming.tests.stubs import REQUEST
 from ftw.theming.tests.stubs import Stub
 from path import Path
 from plone.app.layout.navigation.interfaces import INavigationRoot
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface.verify import verifyObject
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 

--- a/ftw/theming/tests/test_icons.py
+++ b/ftw/theming/tests/test_icons.py
@@ -3,7 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.theming.tests import FunctionalTestCase
 from ftw.theming.utils import IS_PLONE_5
-from unittest2 import skipIf
+from unittest import skipIf
 
 
 @skipIf(IS_PLONE_5, 'Plone 5 no longer uses the IContentIcon interface for brains')

--- a/ftw/theming/tests/test_registry.py
+++ b/ftw/theming/tests/test_registry.py
@@ -9,7 +9,7 @@ from ftw.theming.tests.stubs import CONTEXT
 from ftw.theming.tests.stubs import ProfileInfoStub
 from ftw.theming.tests.stubs import REQUEST
 from operator import attrgetter
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface import provider
 from zope.interface.verify import verifyObject
 

--- a/ftw/theming/tests/test_resource.py
+++ b/ftw/theming/tests/test_resource.py
@@ -4,7 +4,7 @@ from ftw.theming.resource import DynamicSCSSResource
 from ftw.theming.resource import SCSSResource
 from ftw.theming.tests.stubs import CONTEXT
 from ftw.theming.tests.stubs import REQUEST
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface.verify import verifyObject
 
 

--- a/ftw/theming/tests/test_scss_directive.py
+++ b/ftw/theming/tests/test_scss_directive.py
@@ -8,7 +8,7 @@ from ftw.theming.tests.stubs import REQUEST
 from operator import attrgetter
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 from zope.configuration.xmlconfig import ZopeXMLConfigurationError
 from zope.interface import Interface

--- a/ftw/theming/tests/test_uninstall.py
+++ b/ftw/theming/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
 from ftw.testing.genericsetup import apply_generic_setup_layer
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/ftw/theming/utils.py
+++ b/ftw/theming/utils.py
@@ -24,3 +24,7 @@ def get_mimetype_css_class_from_icon_path(icon_path):
     return 'icon-mimetype-img-{}'.format(
         normalizer.normalize(image_filename, max_length=255)
     )
+
+
+def get_mimetype_css_class_from_mime_type(mime_type):
+    return 'icon-mimetype-mt-{}'.format(re.sub('[^A-Za-z0-9]', '-', mime_type))


### PR DESCRIPTION
Up to now, ftw.theming used the "getIcon" catalog column (containing an image path) for generating a HTML structure which can be styled with CSS / font awesome icons.

This strategy does no longer work well in Plone 5 since the "getIcon" metadata column is no longer used.

This change adds an additional strategy for when there is no "getIcon" value on the brain. The new strategy uses the "mime_type" column for generating a css class. This strategy may not work well with Plone 4 / depending on the configuration, that's why we no have two strategies.

Since the strategies generated varying css classes, the icons need to be re-defined based on the "mime_type" value in addition to the definition based on the "getIcon" filename.

The change includes icon definitons for the already styled mimetypes and an update of the icons control panel so that it is easier to control and manage the missing mimetype definitions.

#### Updated control panel
<img width="1468" alt="Bildschirmfoto 2019-12-20 um 14 54 38" src="https://user-images.githubusercontent.com/7469/71259462-ce081b80-2338-11ea-9cc2-a18dc3c360e3.png">


#### Improves ftw.simplelayout download block
<img width="1468" alt="Bildschirmfoto 2019-12-20 um 14 54 33" src="https://user-images.githubusercontent.com/7469/71259487-dc563780-2338-11ea-9cd4-10b5ddc862a2.png">

