### PR TITLE
Fix mimetype icon problem for Plone 4 when there is no icon defined.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix mimetype icon problem for Plone 4 when there is no icon defined. [jone]
 
 
 2.1.0 (2020-01-10)

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from ftw.theming import utils
 from plone.app.layout.icons import icons
 from plone.memoize.instance import memoize
@@ -15,7 +16,9 @@ class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
             return WRAPPER_TEMPLATE.format(
                 cssclass=utils.get_mimetype_css_class_from_icon_path(self.url),
                 content=image_tag)
-        else:
+        elif hasattr(aq_base(self.brain), 'mime_type'):
             return WRAPPER_TEMPLATE.format(
                 cssclass=utils.get_mimetype_css_class_from_mime_type(self.brain.mime_type),
                 content='')
+        else:
+            return None


### PR DESCRIPTION
The icon wrapper was [recently extended](https://github.com/4teamwork/ftw.theming/pull/90) to also support catalog's `mime_type` metadata.
But the `mime_type` metadata was introduced with Plone 5 and is not available with Plone 4.
That's why we need a fallback which does not wrap `getImage`.

These cases are now implemented:
- when `getIcon` is set, use the URL in the `CatalogBrainContentIcon` image tag
- use `brain.mime_type` (only Plone 5)
- fallback to wrapper (Plone 4 without `getIcon`).

I couldn't write a realiable test though. I think it depends on the Plone 4 minor version wether it is reproducible. Tests of other packages are failing at the moment because of that problem and will recover, proving that this solution works.