### PR TITLE
Make getting icon from brain/solr flare more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Extend readme about how use embed-resource with multiple coulors [Nachtalb]
+- Make getting icon from brain/solr flare more robust. [mathias.leimgruber]
 
 
 2.1.1 (2020-01-14)

--- a/ftw/theming/icons.py
+++ b/ftw/theming/icons.py
@@ -16,7 +16,7 @@ class CatalogBrainContentIcon(icons.CatalogBrainContentIcon):
             return WRAPPER_TEMPLATE.format(
                 cssclass=utils.get_mimetype_css_class_from_icon_path(self.url),
                 content=image_tag)
-        elif hasattr(aq_base(self.brain), 'mime_type'):
+        elif getattr(aq_base(self.brain), 'mime_type', False):
             return WRAPPER_TEMPLATE.format(
                 cssclass=utils.get_mimetype_css_class_from_mime_type(self.brain.mime_type),
                 content='')


### PR DESCRIPTION
In case of solr flares the index may contain None, or Missing.Value, both are false. But the attribute exists. 
This fixes the case if the index is not yet fully updated. 